### PR TITLE
Case details page - detailed version

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -4,6 +4,7 @@ import LandingPage from './LandingPage'
 import SurveyDetails from './SurveyDetails'
 import CollectionExerciseDetails from './CollectionExerciseDetails'
 import CaseSearch from './CaseSearch';
+import CaseDetails from './CaseDetails';
 
 class App extends Component {
   state = {
@@ -11,7 +12,9 @@ class App extends Component {
     selectedSurveyName: '',
     selectedCollexId: null,
     selectedCollexName: '',
-    caseSearchActive: false
+    caseSearchActive: false,
+    caseSearchResults: [],
+    selectedCaseId: null,
   }
 
   onOpenSurveyDetails = (survey) => {
@@ -32,7 +35,20 @@ class App extends Component {
 
   onOpenCaseSearch = () => {
     this.setState({
+      caseSearchResults: [], // Clear previous search results
       caseSearchActive: true
+    })
+  }
+
+  onCaseSearchResults = (caseSearchResults) => {
+    this.setState({
+      caseSearchResults: caseSearchResults
+    })
+  }
+
+  onOpenCaseDetails = (caseId) => {
+    this.setState({
+      selectedCaseId: caseId
     })
   }
 
@@ -48,6 +64,12 @@ class App extends Component {
     this.setState({ caseSearchActive: false })
   }
 
+  onBackToCaseSearch = () => {
+    this.setState({
+      selectedCaseId: null
+    })
+  }
+
   render() {
     return (
       <Box>
@@ -61,7 +83,7 @@ class App extends Component {
         {!this.state.selectedSurveyId &&
           <LandingPage onOpenSurveyDetails={this.onOpenSurveyDetails} />
         }
-        {this.state.selectedSurveyId && !this.state.selectedCollexId &&
+        {(this.state.selectedSurveyId && !this.state.selectedCollexId && !this.state.selectedCaseId) &&
           <div>
             <Button onClick={this.onBackToSurveys}>Back</Button>
             <SurveyDetails
@@ -70,7 +92,7 @@ class App extends Component {
               onOpenCollectionExercise={this.onOpenCollectionExercise} />
           </div>
         }
-        {this.state.selectedCollexId && !this.state.caseSearchActive &&
+        {(this.state.selectedCollexId && !this.state.caseSearchActive && !this.state.selectedCaseId) &&
           <div>
             <Button onClick={this.onBackToCollectionExercises}>Back</Button>
             <CollectionExerciseDetails
@@ -80,12 +102,21 @@ class App extends Component {
               onOpenCaseSearch={this.onOpenCaseSearch} />
           </div>
         }
-        {this.state.caseSearchActive &&
+        {(this.state.caseSearchActive && !this.state.selectedCaseId) &&
           <div>
             <Button onClick={this.onBackToCollexDetails}>Back</Button>
             <CaseSearch
+              onOpenCaseDetails={this.onOpenCaseDetails}
+              onCaseSearchResults={this.onCaseSearchResults}
+              caseSearchResults={this.state.caseSearchResults}
               collectionExerciseId={this.state.selectedCollexId}
               collectionExerciseName={this.state.selectedCollexName} />
+          </div>
+        }
+        {this.state.selectedCaseId &&
+          <div>
+            <Button onClick={this.onBackToCaseSearch}>Back</Button>
+            <CaseDetails caseId={this.state.selectedCaseId} />
           </div>
         }
       </Box>

--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -1,32 +1,114 @@
 import React, { Component } from 'react';
 import '@fontsource/roboto';
-import { Button, Dialog, DialogContent } from '@material-ui/core';
+import { Typography, Paper } from '@material-ui/core';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
 
 class CaseDetails extends Component {
+  state = {
+    case: null
+  }
+
+  componentDidMount() {
+    this.getCase()
+  }
+
+  getCase = async () => {
+    const response = await fetch('/cases/' + this.props.caseId)
+    const caseJson = await response.json()
+
+    if (response.ok) {
+      this.setState({ case: caseJson })
+    }
+  }
+
   render() {
+    var caseEvents
+    var uacQids
+
+    if (this.state.case) {
+      caseEvents = this.state.case.events.map((event, index) => (
+        <TableRow key={index}>
+          <TableCell component="th" scope="row">
+            {event.eventDate}
+          </TableCell>
+          <TableCell component="th" scope="row">
+            {event.eventDescription}
+          </TableCell>
+          <TableCell component="th" scope="row">
+            {event.eventSource}
+          </TableCell>
+        </TableRow>
+      ))
+
+      uacQids = this.state.case.uacQidLinks.map((uacQidLink, index) => (
+        <TableRow key={index}>
+          <TableCell component="th" scope="row">
+            {uacQidLink.qid}
+          </TableCell>
+          <TableCell component="th" scope="row">
+            {uacQidLink.createdAt}
+          </TableCell>
+          <TableCell component="th" scope="row">
+            {uacQidLink.lastUpdatedAt}
+          </TableCell>
+          <TableCell component="th" scope="row">
+            {uacQidLink.active ? 'Yes' : 'No'}
+          </TableCell>
+        </TableRow>
+      ))
+    }
 
     return (
-      <Dialog open={this.props.showDetails} onClose={this.props.onClickAway}>
-        <DialogContent style={{ padding: 30 }}>
+      <div style={{ padding: 20 }}>
+        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
+          Case Details
+        </Typography>
+        {this.state.case &&
           <div>
-            {this.props.case &&
-              <div>
-                <div>Case ref: {this.props.case.caseRef}</div>
-                <div>Created at: {this.props.case.createdAt}</div>
-                <div>Last updated at: {this.props.case.lastUpdatedAt}</div>
-                <div>Receipted: {this.props.case.receiptReceived ? "Yes" : "No"}</div>
-                <div>Refused: {this.props.case.refusalReceived ? this.props.case.refusalReceived : "No"}</div>
-                <div>Invalid: {this.props.case.addressInvalid ? "Yes" : "No"}</div>
-                <div>Launched EQ: {this.props.case.surveyLaunched ? "Yes" : "No"}</div>
-              </div>
-            }
-            <Button onClick={this.props.onCloseDetails} variant="contained" style={{ margin: 10 }}>
-              Close
-            </Button>
+            <div>Case ref: {this.state.case.caseRef}</div>
+            <div>Created at: {this.state.case.createdAt}</div>
+            <div>Last updated at: {this.state.case.lastUpdatedAt}</div>
+            <div>Receipted: {this.state.case.receiptReceived ? "Yes" : "No"}</div>
+            <div>Refused: {this.state.case.refusalReceived ? this.state.case.refusalReceived : "No"}</div>
+            <div>Invalid: {this.state.case.addressInvalid ? "Yes" : "No"}</div>
+            <div>Launched EQ: {this.state.case.surveyLaunched ? "Yes" : "No"}</div>
+            <TableContainer component={Paper} style={{ marginTop: 20 }}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Date</TableCell>
+                    <TableCell>Description</TableCell>
+                    <TableCell>Source</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {caseEvents}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <TableContainer component={Paper} style={{ marginTop: 20 }}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>QID</TableCell>
+                    <TableCell>Created At</TableCell>
+                    <TableCell>Last Updated At</TableCell>
+                    <TableCell>Active</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {uacQids}
+                </TableBody>
+              </Table>
+            </TableContainer>
           </div>
-        </DialogContent>
-      </Dialog>
-
+        }
+      </div>
     )
   }
 }

--- a/ui/src/CaseSearch.js
+++ b/ui/src/CaseSearch.js
@@ -18,20 +18,16 @@ import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import CaseDetails from './CaseDetails';
 
 
 class CaseSearch extends Component {
   state = {
-    cases: [],
     sampleColumns: [],
     searchDialogOpen: false,
     contains: '',
     containsValidationError: false,
     column: '',
-    columnValidationError: false,
-    showDetails: false,
-    selectedCase: null
+    columnValidationError: false
   }
 
   componentDidMount() {
@@ -69,10 +65,14 @@ class CaseSearch extends Component {
 
     const response = await fetch('/cases/search/findBySampleContains?collexId=' + this.props.collectionExerciseId + '&key=' + this.state.column + '&value=' + this.state.contains)
     const search_result_json = await response.json()
-    this.setState({
-      cases: search_result_json._embedded.cases,
-      searchDialogOpen: false
-    })
+
+    if (response.ok) {
+      this.props.onCaseSearchResults(search_result_json._embedded.cases)
+
+      this.setState({
+        searchDialogOpen: false
+      })
+    }
   }
 
   onOpenSearchDialog = () => {
@@ -106,13 +106,6 @@ class CaseSearch extends Component {
     })
   }
 
-  onOpenCaseDetails = (caze) => {
-    this.setState({
-      showDetails: true,
-      selectedCase: caze
-    })
-  }
-
   onCloseDetails = () => {
     this.setState({
       showDetails: false
@@ -120,6 +113,8 @@ class CaseSearch extends Component {
   }
 
   getCaseCells = (caze) => {
+    const caseId = caze._links.self.href.split('/')[4]
+
     let caseCells = this.state.sampleColumns.map(sampleColumn => (
       <TableCell>{caze.sample[sampleColumn]}</TableCell>
     ))
@@ -127,7 +122,7 @@ class CaseSearch extends Component {
     caseCells.push((
       <TableCell>
         <Button
-          onClick={() => this.onOpenCaseDetails(caze)}
+          onClick={() => this.props.onOpenCaseDetails(caseId)}
           variant="contained">
           Open
         </Button>
@@ -150,7 +145,7 @@ class CaseSearch extends Component {
       <TableCell key={-1}>Action</TableCell>
     ))
 
-    const caseTableRows = this.state.cases.map((caze, index) => (
+    const caseTableRows = this.props.caseSearchResults.map((caze, index) => (
       <TableRow key={index}>
         {this.getCaseCells(caze)}
       </TableRow>
@@ -207,7 +202,6 @@ class CaseSearch extends Component {
             </div>
           </DialogContent>
         </Dialog>
-        <CaseDetails showDetails={this.state.showDetails} onCloseDetails={this.onCloseDetails} case={this.state.selectedCase} />
       </div>
     )
   }


### PR DESCRIPTION
# Motivation and Context
The case details popup didn't show any event history or UAC/QIDs.

# What has changed
Created case details page which shows event history & UAC/QIDs.

# How to test?
Load a sample. Run the UI using `make run-dev-ui` and go to http://localhost:3000 then search for a case and open the details.

# Links
Trello: https://trello.com/c/7yGpUzcW

# Screenshots (if appropriate):
<img width="1083" alt="Screenshot 2021-07-08 at 08 29 52" src="https://user-images.githubusercontent.com/41681172/124881361-278d7500-dfc7-11eb-80a4-ced73bb74699.png">
