### PR TITLE
Fix performance issue with massive samples

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Job.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Job.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ssdc.supporttool.model.entity;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -46,7 +45,7 @@ public class Job {
   @Column
   private JobStatus jobStatus;
 
-  @OneToMany(mappedBy = "job", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "job")
   private List<JobRow> jobRows;
 
   @Column private String fatalErrorDescription;


### PR DESCRIPTION
# Motivation and Context
Performance was bad, when testing with a 450k sample.

# What has changed
Removed the `cascade = CascadeType.ALL` from the JobRows, so that Hibernate wouldn't have to figure out if we had fiddled with any of the rows, every time we update the Job progress.

# How to test?
Load a 450k sample. Profit.

# Links
Trello: https://trello.com/c/0eA4YuSI