### PR TITLE
Fix CRUD REST API crashing due to stack overflow

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -24,8 +25,10 @@ import org.hibernate.annotations.TypeDefs;
 public class Event {
   @Id private UUID id;
 
+  @JsonIgnore // Required to avoid stack overflow when using Spring auto-generated CRUD REST API
   @ManyToOne private UacQidLink uacQidLink;
 
+  @JsonIgnore // Required to avoid stack overflow when using Spring auto-generated CRUD REST API
   @ManyToOne private Case caze;
 
   @Column(columnDefinition = "timestamp with time zone")

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/Event.java
@@ -26,10 +26,12 @@ public class Event {
   @Id private UUID id;
 
   @JsonIgnore // Required to avoid stack overflow when using Spring auto-generated CRUD REST API
-  @ManyToOne private UacQidLink uacQidLink;
+  @ManyToOne
+  private UacQidLink uacQidLink;
 
   @JsonIgnore // Required to avoid stack overflow when using Spring auto-generated CRUD REST API
-  @ManyToOne private Case caze;
+  @ManyToOne
+  private Case caze;
 
   @Column(columnDefinition = "timestamp with time zone")
   private OffsetDateTime eventDate;


### PR DESCRIPTION
# Motivation and Context
When the Spring auto-generated CRUD API attempts to gather all the data about events, it tries to follow all links, and in so doing it ends up in an infinite loop, which eventually causes a stack overflow.

# What has changed
Told Jackson to ignore one end of the bidirectional relationship between events and cases/uac-qid-links.

# How to test?
Load a sample. Send in a few different types of event (receipt, refusal, deactivate UAC etc) and then use the case search feature in the UI to view the case - it should work; not fail.

# Links
Trello: https://trello.com/c/3gYzhczr