### PR TITLE
Upgrade to Spring Boot v2.5.2 / Data REST v3.5.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.7.RELEASE</version>
+    <version>2.5.2</version>
   </parent>
 
   <properties>
@@ -91,6 +91,17 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,21 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <!-- Can't upgrade to Spring Boot 2.5.x because of bug with Jackson deserialisation -->
-    <version>2.4.8</version>
+    <version>2.5.2</version>
   </parent>
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
   </properties>
+
+  <!-- TODO - Remove this when new Spring Boot is released with bug fix -->
+  <repositories>
+    <repository>
+      <id>spring-snapshots</id>
+      <url>https://repo.spring.io/snapshot</url>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
 
   <dependencies>
     <dependency>
@@ -27,7 +35,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
+
+      <!-- TODO - Remove this when new Spring Boot is released with bug fix -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.data</groupId>
+          <artifactId>spring-data-rest-webmvc</artifactId>
+        </exclusion>
+      </exclusions>
+
     </dependency>
+
+    <!-- TODO - Remove this when new Spring Boot is released with bug fix -->
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-rest-webmvc</artifactId>
+      <version>3.5.3-SNAPSHOT</version>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,8 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.2</version>
+    <!-- Can't upgrade to Spring Boot 2.5.x because of bug with Jackson deserialisation -->
+    <version>2.4.8</version>
   </parent>
 
   <properties>
@@ -52,7 +53,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.6</version>
+      <version>1.18.20</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,11 +18,10 @@ spring:
     username: postgres
     password: postgres
     driverClassName: org.postgresql.Driver
-    initialization-mode: always
     hikari:
       maximumPoolSize: 50
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
     hibernate:
       ddl-auto: validate
     properties:


### PR DESCRIPTION
# Motivation and Context
We were running on a version of Spring Boot from May 2020.

# What has changed
Upgraded to the latest and greatest Spring Boot.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/8MZx3DE9