### PR TITLE
Make routing keys consistent

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
@@ -38,8 +38,8 @@ public class CaseService {
   @Value("${queueconfig.invalid-address-event-routing-key}")
   private String invalidAddressEventRoutingKey;
 
-  @Value("${queueconfig.fulfilment-queue}")
-  private String fulfilmentQueue;
+  @Value("${queueconfig.fulfilment-routing-key}")
+  private String fulfilmentRoutingKey;
 
   public CaseService(CaseRepository caseRepository, RabbitTemplate rabbitTemplate) {
     this.caseRepository = caseRepository;
@@ -128,6 +128,6 @@ public class CaseService {
     responseManagementEvent.setEvent(eventDTO);
     responseManagementEvent.setPayload(payloadDTO);
 
-    rabbitTemplate.convertAndSend(fulfilmentQueue, responseManagementEvent);
+    rabbitTemplate.convertAndSend(eventsExchange, fulfilmentRoutingKey, responseManagementEvent);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,7 @@ printsupplierconfig: '{"SUPPLIER_A":{"sftpDirectory":"foo","encryptionKeyFilenam
 queueconfig:
   case-event-exchange: events
   sample-queue: supportTool.caseProcessor.sample
-  fulfilment-queue: events.caseProcessor.fulfilment
-  deactivate-uac-routing-key: events.caseProcessor.deactivateUac
-  refusal-event-routing-key: events.caseProcessor.refusal
-  invalid-address-event-routing-key: events.caseProcessor.invalidAddress
+  fulfilment-routing-key: events.fulfilment
+  deactivate-uac-routing-key: events.deactivateUac
+  refusal-event-routing-key: events.refusal
+  invalid-address-event-routing-key: events.invalidAddress


### PR DESCRIPTION
# Motivation and Context
Routing key != queue name. If you want to send directly to a queue, use the default exchange. Otherwise, use the `events` exchange with a meaningful routing key.

# What has changed
Named the routing keys better.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/4CgML4w6