### PR TITLE
Removal of Bad Events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/EventType.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/EventType.java
@@ -2,10 +2,8 @@ package uk.gov.ons.ssdc.supporttool.model.entity;
 
 public enum EventType {
   CASE_CREATED,
-  UAC_UPDATED,
   RESPONSE_RECEIVED,
   REFUSAL_RECEIVED,
-  SAMPLE_LOADED,
   SURVEY_LAUNCHED,
   ADDRESS_NOT_VALID,
   RESPONDENT_AUTHENTICATED,


### PR DESCRIPTION
# Motivation and Context
CASE_CREATED & UAC_UPDATED are unused (database) event types.
SAMPLE_LOADED is misleading, because it does not tell us when a sample was loaded, but in fact when we received an instruction to create a case.
We should get rid of SAMPLE_LOADED and UAC_UPDATED and store a CASE_CREATED when we create a case.

# What has changed
Removal of bad events

# How to test?
Build images and run ATs

# Links
https://trello.com/c/JnLxj02F
