### PR TITLE
Make it easier to test RBAC

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -25,7 +25,9 @@ public class UserIdentity {
 
   private TokenVerifier tokenVerifier = null;
 
-  public UserIdentity(UserRepository userRepository, @Value("${iapaudience}") String iapAudience,
+  public UserIdentity(
+      UserRepository userRepository,
+      @Value("${iapaudience}") String iapAudience,
       @Value("${dummyuseridentity}") String dummyUserIdentity) {
     this.userRepository = userRepository;
     this.iapAudience = iapAudience;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -21,12 +21,15 @@ public class UserIdentity {
 
   private final UserRepository userRepository;
   private final String iapAudience;
+  private final String dummyUserIdentity;
 
   private TokenVerifier tokenVerifier = null;
 
-  public UserIdentity(UserRepository userRepository, @Value("${iapaudience}") String iapAudience) {
+  public UserIdentity(UserRepository userRepository, @Value("${iapaudience}") String iapAudience,
+      @Value("${dummyuseridentity}") String dummyUserIdentity) {
     this.userRepository = userRepository;
     this.iapAudience = iapAudience;
+    this.dummyUserIdentity = dummyUserIdentity;
   }
 
   public void checkUserPermission(
@@ -107,7 +110,7 @@ public class UserIdentity {
       // This should throw an exception if we're running in GCP
       // We are faking the email address so that we can test locally
       // TODO: remove this before releasing to production!
-      return "dummy@fake-email.com";
+      return dummyUserIdentity;
     } else {
       return verifyJwtAndGetEmail(jwtToken);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,9 @@ management:
 
 iapaudience: DUMMY
 
+# TODO: Remove this before releasing to prod
+dummyuseridentity: dummy@fake-email.com
+
 printsupplierconfig: '{"SUPPLIER_A":{"sftpDirectory":"foo","encryptionKeyFilename": "bar"},"SUPPLIER_B":{"sftpDirectory":"foo","encryptionKeyFilename":"bar"}}'
 
 queueconfig:


### PR DESCRIPTION
# Motivation and Context
Currently, when testing via Docker Dev on a local machine, the identity is faked as `dummy@fake-email.com` which is also granted super user permission, by default.

We need a mechanism to fake different user identities, so that we can test that RBAC is working.

# What has changed
Created environment variable called `DUMMY_USER` in the `.env` file in docker dev. This can be changed to fake any email you want, but you will need to ensure the user is present in the `users` table in the database and has been granted permissions via group membership etc.

# How to test?
Change the user to anything other than `dummy@fake-email.com` and then set it up in the DB with some permissions, and you should see RBAC working locally.

# Links
Trello: https://trello.com/c/oO5I3bIz