### PR TITLE
Replace deprecated StringUtils.isEmpty with hasText

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -108,7 +108,7 @@ public class UserIdentity {
   }
 
   public String getUserEmail(String jwtToken) {
-    if (StringUtils.isEmpty(jwtToken)) {
+    if (!StringUtils.hasText(jwtToken)) {
       // This should throw an exception if we're running in GCP
       // We are faking the email address so that we can test locally
       // TODO: remove this before releasing to production!

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/validation/MandatoryRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/validation/MandatoryRule.java
@@ -2,13 +2,14 @@ package uk.gov.ons.ssdc.supporttool.validation;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import java.util.Optional;
+import org.springframework.util.StringUtils;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class MandatoryRule implements Rule {
 
   @Override
   public Optional<String> checkValidity(String data) {
-    if (data.strip().isEmpty()) {
+    if (!StringUtils.hasText(data)) {
       return Optional.of("Mandatory value missing");
     }
 


### PR DESCRIPTION
# Motivation and Context
Spring Boot 2.5.2 deprecates StringUtils.isEmpty.

# What has changed
Used `StringUtils.hasText` instead.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/f7yh1qjL