### PR TITLE
Spike delete uploaded sample files when done

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.supporttool.schedule;
 
 import com.opencsv.CSVReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
@@ -9,6 +10,8 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import uk.gov.ons.ssdc.supporttool.model.entity.Job;
 import uk.gov.ons.ssdc.supporttool.model.entity.JobStatus;
 import uk.gov.ons.ssdc.supporttool.model.repository.JobRepository;
@@ -57,6 +60,17 @@ public class RowStager {
 
         job.setJobStatus(jobStatus);
         jobRepository.saveAndFlush(job);
+
+        // The file is now fully staged, or we got a fatal error, so we can delete the file
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+          TransactionSynchronizationManager.registerSynchronization(
+              new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                  new File("/tmp/" + job.getFileId()).delete();
+                }
+              });
+        }
       } catch (IOException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
# Motivation and Context
Uploaded sample files fill up the `/tmp` directory because they're not cleaned up.

# What has changed
Clean up files when we're done with them.

# How to test?
Upload a bunch of sample files and check that the /tmp directory files are deleted.

# Links
Trello: https://trello.com/c/oi6VFzJE