### PR TITLE
Make file upload storage directory configurable

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -28,6 +29,9 @@ public class FileUploadEndpoint {
   private final JobRepository jobRepository;
   private final UserIdentity userIdentity;
   private final CollectionExerciseRepository collectionExerciseRepository;
+
+  @Value("${file-upload-storage-path}")
+  private String fileUploadStoragePath;
 
   public FileUploadEndpoint(
       JobRepository jobRepository,
@@ -57,7 +61,7 @@ public class FileUploadEndpoint {
 
     UUID fileId = UUID.randomUUID();
 
-    try (FileOutputStream fos = new FileOutputStream("/tmp/" + fileId);
+    try (FileOutputStream fos = new FileOutputStream(fileUploadStoragePath + fileId);
         BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()))) {
       Job job = new Job();
       job.setId(UUID.randomUUID());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ssdc.supporttool.model.entity.Job;
@@ -17,6 +18,9 @@ import uk.gov.ons.ssdc.supporttool.utility.SampleColumnHelper;
 public class FileStager {
 
   private final JobRepository jobRepository;
+
+  @Value("${file-upload-storage-path}")
+  private String fileUploadStoragePath;
 
   public FileStager(JobRepository jobRepository) {
     this.jobRepository = jobRepository;
@@ -40,7 +44,7 @@ public class FileStager {
   }
 
   private JobStatus checkHeaderRow(Job job) {
-    try (Reader reader = Files.newBufferedReader(Path.of("/tmp/" + job.getFileId()));
+    try (Reader reader = Files.newBufferedReader(Path.of(fileUploadStoragePath + job.getFileId()));
         CSVReader csvReader =
             new CSVReader(reader, job.getCollectionExercise().getSurvey().getSampleSeparator())) {
       JobStatus jobStatus = JobStatus.STAGING_IN_PROGRESS;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
@@ -77,7 +77,7 @@ public class FileStager {
             new TransactionSynchronization() {
               @Override
               public void afterCompletion(int status) {
-                new File("/tmp/" + job.getFileId()).delete();
+                new File(fileUploadStoragePath + job.getFileId()).delete();
               }
             });
       }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -72,7 +72,7 @@ public class RowStager {
               new TransactionSynchronization() {
                 @Override
                 public void afterCompletion(int status) {
-                  new File("/tmp/" + job.getFileId()).delete();
+                  new File(fileUploadStoragePath + job.getFileId()).delete();
                 }
               });
         }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,9 @@ public class RowStager {
   private final JobRepository jobRepository;
   private final RowChunkStager rowChunkStager;
 
+  @Value("${file-upload-storage-path}")
+  private String fileUploadStoragePath;
+
   public RowStager(JobRepository jobRepository, RowChunkStager rowChunkStager) {
     this.jobRepository = jobRepository;
     this.rowChunkStager = rowChunkStager;
@@ -30,7 +34,8 @@ public class RowStager {
     List<Job> jobs = jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS);
 
     for (Job job : jobs) {
-      try (Reader reader = Files.newBufferedReader(Path.of("/tmp/" + job.getFileId()));
+      try (Reader reader =
+              Files.newBufferedReader(Path.of(fileUploadStoragePath + job.getFileId()));
           CSVReader csvReader =
               new CSVReader(reader, job.getCollectionExercise().getSurvey().getSampleSeparator())) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,3 +83,5 @@ queueconfig:
   deactivate-uac-routing-key: events.deactivateUac
   refusal-event-routing-key: events.refusal
   invalid-address-event-routing-key: events.invalidAddress
+
+file-upload-storage-path: /tmp/


### PR DESCRIPTION
# Motivation and Context
The file storage was hardcoded to use `/tmp/`, this is fine locally but when running in the cloud we need to be able to point it to a persisted directory.

# What has changed
- Replace hardcoded paths with config variable

# How to test?
Eyeball and run tests with `mvn`

# Links
https://trello.com/c/0T29EVaG/2541-work-out-realistic-infrastructure-size-for-performance-testing-eg-db-disk-rabbit-mq-memory-etc-1-day