### PR TITLE
Spike switch to google pubsub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,18 +18,6 @@
     <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Hoxton.SR12</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <!-- TODO - Remove this when new Spring Boot is released with bug fix -->
   <repositories>
     <repository>
@@ -68,10 +56,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,18 @@
     <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>Hoxton.SR12</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <!-- TODO - Remove this when new Spring Boot is released with bug fix -->
   <repositories>
     <repository>
@@ -56,20 +68,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-amqp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-amqp</artifactId>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -94,11 +96,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-stackdriver</artifactId>
       <version>1.5.1</version>
     </dependency>
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
@@ -2,33 +2,12 @@ package uk.gov.ons.ssdc.supporttool.config;
 
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
-import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
-import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
 
 @Configuration
 @EnableScheduling
 public class AppConfig {
-  @Bean
-  public PubSubTemplate pubSubTemplate(
-      PublisherFactory publisherFactory,
-      SubscriberFactory subscriberFactory,
-      JacksonPubSubMessageConverter jacksonPubSubMessageConverter) {
-    PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
-    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverter);
-    return pubSubTemplate;
-  }
-
-  @Bean
-  public JacksonPubSubMessageConverter messageConverter() {
-    return new JacksonPubSubMessageConverter(ObjectMapperFactory.objectMapper());
-  }
-
   @PostConstruct
   public void init() {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
@@ -2,9 +2,10 @@ package uk.gov.ons.ssdc.supporttool.config;
 
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -14,17 +15,18 @@ import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
 @EnableScheduling
 public class AppConfig {
   @Bean
-  public RabbitTemplate rabbitTemplate(
-      ConnectionFactory connectionFactory, Jackson2JsonMessageConverter messageConverter) {
-    RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-    rabbitTemplate.setMessageConverter(messageConverter);
-    rabbitTemplate.setChannelTransacted(true);
-    return rabbitTemplate;
+  public PubSubTemplate pubSubTemplate(
+      PublisherFactory publisherFactory,
+      SubscriberFactory subscriberFactory,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverter) {
+    PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
+    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverter);
+    return pubSubTemplate;
   }
 
   @Bean
-  public Jackson2JsonMessageConverter messageConverter() {
-    return new Jackson2JsonMessageConverter(ObjectMapperFactory.objectMapper());
+  public JacksonPubSubMessageConverter messageConverter() {
+    return new JacksonPubSubMessageConverter(ObjectMapperFactory.objectMapper());
   }
 
   @PostConstruct

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/messaging/MessageSender.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/messaging/MessageSender.java
@@ -1,0 +1,25 @@
+package uk.gov.ons.ssdc.supporttool.messaging;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ssdc.supporttool.model.entity.MessageToSend;
+import uk.gov.ons.ssdc.supporttool.model.repository.MessageToSendRepository;
+import uk.gov.ons.ssdc.supporttool.utility.JsonHelper;
+
+@Component
+public class MessageSender {
+  private final MessageToSendRepository messageToSendRepository;
+
+  public MessageSender(MessageToSendRepository messageToSendRepository) {
+    this.messageToSendRepository = messageToSendRepository;
+  }
+
+  public void sendMessage(String destinationTopic, Object message) {
+    MessageToSend messageToSend = new MessageToSend();
+    messageToSend.setId(UUID.randomUUID());
+    messageToSend.setDestinationTopic(destinationTopic);
+    messageToSend.setMessageBody(JsonHelper.convertObjectToJson(message));
+
+    messageToSendRepository.saveAndFlush(messageToSend);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/MessageToSend.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/entity/MessageToSend.java
@@ -1,0 +1,38 @@
+package uk.gov.ons.ssdc.supporttool.model.entity;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+
+@Data
+@Entity
+public class MessageToSend {
+  @Id private UUID id;
+
+  @Column private String destinationTopic;
+
+  @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
+  @Column
+  private byte[] messageBody;
+
+  public void setMessageBody(String messageBodyStr) {
+    if (messageBodyStr == null) {
+      messageBody = null;
+    } else {
+      messageBody = messageBodyStr.getBytes();
+    }
+  }
+
+  public String getMessageBody() {
+    if (messageBody == null) {
+      return null;
+    }
+
+    return new String(messageBody);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/MessageToSendRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/MessageToSendRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.ssdc.supporttool.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.ssdc.supporttool.model.entity.MessageToSend;
+
+public interface MessageToSendRepository extends JpaRepository<MessageToSend, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/utility/JsonHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/utility/JsonHelper.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.ssdc.supporttool.utility;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonHelper {
+  private static final ObjectMapper objectMapper = ObjectMapperFactory.objectMapper();
+
+  public static String convertObjectToJson(Object obj) {
+    try {
+      return objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed converting Object To Json", e);
+    }
+  }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,7 +1,3 @@
 spring:
   datasource:
     url: jdbc:postgresql://postgres:5432/postgres
-
-  rabbitmq:
-    host: rabbitmq
-    port: 5672

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,11 @@ spring:
           lob:
             non_contextual_creation: true
 
-  rabbitmq:
-    username: guest
-    password: guest
-    host: localhost
-    port: 6672
-    virtualhost: /
+  cloud:
+    gcp:
+      pubsub:
+        emulator-host: localhost:8538
+        project-id: project
 
   task:
     scheduling:
@@ -63,15 +62,6 @@ management:
   endpoint:
     health:
       enabled: true
-  metrics:
-    tags:
-      application: Support Tool
-      pod: ${HOSTNAME}
-    export:
-      stackdriver:
-        project-id: dummy-project-id
-        enabled: false
-        step: PT1M
 
 iapaudience: DUMMY
 
@@ -81,11 +71,11 @@ dummyuseridentity: dummy@fake-email.com
 printsupplierconfig: '{"SUPPLIER_A":{"sftpDirectory":"foo","encryptionKeyFilename": "bar"},"SUPPLIER_B":{"sftpDirectory":"foo","encryptionKeyFilename":"bar"}}'
 
 queueconfig:
-  case-event-exchange: events
-  sample-queue: supportTool.caseProcessor.sample
-  fulfilment-routing-key: events.fulfilment
-  deactivate-uac-routing-key: events.deactivateUac
-  refusal-event-routing-key: events.refusal
-  invalid-address-event-routing-key: events.invalidAddress
+  sample-topic: supportTool.caseProcessor.sample.topic
+  fulfilment-topic: events.caseProcessor.fulfilment.topic
+  deactivate-uac-topic: events.caseProcessor.deactivateUac.topic
+  refusal-event-topic: events.caseProcessor.refusal.topic
+  invalid-address-event-topic: events.caseProcessor.invalidAddress.topic
+  publishtimeout: 30  # In seconds
 
 file-upload-storage-path: /tmp/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,6 @@ spring:
           lob:
             non_contextual_creation: true
 
-  cloud:
-    gcp:
-      pubsub:
-        emulator-host: localhost:8538
-        project-id: project
-
   task:
     scheduling:
       pool:


### PR DESCRIPTION
# Motivation and Context
We wanted to get rid of RabbitMQ because it's not cloud native, and it's therefore a pain to support and maintain in the cloud, plus we needed to migrate away from classic queues anyway, so why not just switch to Google PubSub, given that we're hosted in GCP?

# What has changed
Replaced RabbitMQ with Google PubSub.

# How to test?
Run `make test`

# Links
Trello: https://trello.com/c/W86A71JQ