### PR TITLE
Fix massive sample load failure

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -13,11 +12,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
-import uk.gov.ons.ssdc.supporttool.model.entity.CollectionExercise;
-import uk.gov.ons.ssdc.supporttool.model.entity.Job;
-import uk.gov.ons.ssdc.supporttool.model.entity.JobStatus;
-import uk.gov.ons.ssdc.supporttool.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.repository.CollectionExerciseRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.JobRepository;
 import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
@@ -42,34 +36,12 @@ public class FileUploadEndpoint {
   }
 
   @PostMapping("/api/upload")
-  public ResponseEntity<?> handleFileUpload(
-      @RequestParam("file") MultipartFile file,
-      @RequestParam(value = "collectionExerciseId") UUID collectionExerciseId,
-      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-
-    // Check that collex exists
-    Optional<CollectionExercise> collexOpt =
-        collectionExerciseRepository.findById(collectionExerciseId);
-    if (!collexOpt.isPresent()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Collection exercise not found");
-    }
-
-    // Check user is authorised to upload sample for this survey
-    userIdentity.checkUserPermission(
-        userEmail, collexOpt.get().getSurvey(), UserGroupAuthorisedActivityType.LOAD_SAMPLE);
+  public ResponseEntity<UUID> handleFileUpload(@RequestParam("file") MultipartFile file) {
 
     UUID fileId = UUID.randomUUID();
 
     try (FileOutputStream fos = new FileOutputStream(fileUploadStoragePath + fileId);
         BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()))) {
-      Job job = new Job();
-      job.setId(UUID.randomUUID());
-
-      job.setFileName(file.getOriginalFilename());
-      job.setFileId(fileId);
-      job.setJobStatus(JobStatus.FILE_UPLOADED);
-      job.setCreatedBy(userEmail);
-      job.setCollectionExercise(collexOpt.get());
 
       int rowCount = 0;
       while (reader.ready()) {
@@ -79,13 +51,10 @@ public class FileUploadEndpoint {
         fos.write("\n".getBytes());
       }
 
-      job.setFileRowCount(rowCount);
-
-      jobRepository.saveAndFlush(job);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
 
-    return new ResponseEntity<>(null, HttpStatus.CREATED);
+    return new ResponseEntity<UUID>(fileId, HttpStatus.CREATED);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FileUploadEndpoint.java
@@ -43,10 +43,8 @@ public class FileUploadEndpoint {
     try (FileOutputStream fos = new FileOutputStream(fileUploadStoragePath + fileId);
         BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()))) {
 
-      int rowCount = 0;
       while (reader.ready()) {
         String line = reader.readLine();
-        rowCount++;
         fos.write(line.getBytes());
         fos.write("\n".getBytes());
       }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -197,13 +197,12 @@ public class JobEndpoint {
         userEmail, collexOpt.get().getSurvey(), UserGroupAuthorisedActivityType.LOAD_SAMPLE);
 
     File file = new File(fileUploadStoragePath + fileId);
-    long count;
+    int rowCount;
     try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
-      count = stream.count();
+      rowCount = (int) stream.count();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    int rowCount = (int) count;
 
     Job job = new Job();
     job.setId(UUID.randomUUID());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -180,7 +180,7 @@ public class JobEndpoint {
 
   @PostMapping
   public ResponseEntity<?> submitUploadJob(
-      @RequestParam(value = "fileId") String fileId,
+      @RequestParam(value = "fileId") UUID fileId,
       @RequestParam(value = "fileName") String fileName,
       @RequestParam(value = "collectionExerciseId") UUID collectionExerciseId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
@@ -209,7 +209,7 @@ public class JobEndpoint {
     job.setId(UUID.randomUUID());
 
     job.setFileName(fileName);
-    job.setFileId(UUID.fromString(fileId));
+    job.setFileId(fileId);
     job.setJobStatus(JobStatus.FILE_UPLOADED);
     job.setCreatedBy(userEmail);
     job.setCollectionExercise(collexOpt.get());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentityInterceptor.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentityInterceptor.java
@@ -13,6 +13,10 @@ public class UserIdentityInterceptor implements HandlerInterceptor {
 
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    if (request.getRequestURI().equals("/api/upload")) {
+      // Don't bother with identity for file uploads because the JWT claim expires after 10 mins
+      return true;
+    }
     String jwtToken = request.getHeader("x-goog-iap-jwt-assertion");
     String userEmail = userIdentity.getUserEmail(jwtToken);
     request.setAttribute("userEmail", userEmail);

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -78,17 +78,14 @@ class SampleUpload extends Component {
       .then((data) => {
         // send the job details
         const fileId = data.data;
-        const formData = new FormData();
-        formData.append("fileId", data.data);
-        formData.append("fileName", fileName);
-        formData.append(
-          "collectionExerciseId",
-          this.props.collectionExerciseId
-        );
+        const jobData = new FormData();
+        jobData.append("fileId", data.data);
+        jobData.append("fileName", fileName);
+        jobData.append("collectionExerciseId", this.props.collectionExerciseId);
 
         const response = fetch(`/api/job`, {
           method: "POST",
-          body: formData,
+          body: jobData,
         });
 
         // Hide the progress dialog and flash the snackbar message

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -52,7 +52,6 @@ class SampleUpload extends Component {
     const formData = new FormData();
     formData.append("file", e.target.files[0]);
     formData.append("bulkProcess", "SAMPLE");
-    formData.append("collectionExerciseId", this.props.collectionExerciseId);
 
     const fileName = e.target.files[0].name;
     // Reset the file
@@ -77,21 +76,20 @@ class SampleUpload extends Component {
         },
       })
       .then((data) => {
-
         // send the job details
         const fileId = data.data;
         const formData = new FormData();
         formData.append("fileId", data.data);
         formData.append("fileName", fileName);
-        formData.append("collectionExerciseId", this.props.collectionExerciseId);
-
-        const response = fetch(
-            `/api/job`,
-            {
-              method: "POST",
-              body: formData,
-            }
+        formData.append(
+          "collectionExerciseId",
+          this.props.collectionExerciseId
         );
+
+        const response = fetch(`/api/job`, {
+          method: "POST",
+          body: formData,
+        });
 
         // Hide the progress dialog and flash the snackbar message
         this.setState({

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -54,6 +54,7 @@ class SampleUpload extends Component {
     formData.append("bulkProcess", "SAMPLE");
     formData.append("collectionExerciseId", this.props.collectionExerciseId);
 
+    const fileName = e.target.files[0].name;
     // Reset the file
     e.target.value = null;
 
@@ -76,6 +77,22 @@ class SampleUpload extends Component {
         },
       })
       .then((data) => {
+
+        // send the job details
+        const fileId = data.data;
+        const formData = new FormData();
+        formData.append("fileId", data.data);
+        formData.append("fileName", fileName);
+        formData.append("collectionExerciseId", this.props.collectionExerciseId);
+
+        const response = fetch(
+            `/api/job`,
+            {
+              method: "POST",
+              body: formData,
+            }
+        );
+
         // Hide the progress dialog and flash the snackbar message
         this.setState({
           fileProgress: 1.0,

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -51,7 +51,6 @@ class SampleUpload extends Component {
 
     const formData = new FormData();
     formData.append("file", e.target.files[0]);
-    formData.append("bulkProcess", "SAMPLE");
 
     const fileName = e.target.files[0].name;
     // Reset the file


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When loading a massive sample or on a slow connection and the sample load takes more than 10 minutes, the JWT token times out and the load fails.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The sample load and the insertion of the job has been split into two endpoints. 
The identity isn't checked when the upload endpoint is called.
The existing `/api/job` endpoint now has a POST endpoint to create the job details.
The frontend calls both endpoints as part of the sample upload process.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

- Build the image and run in docker. `make test` on the acceptance tests [branch of the same name](https://github.com/ONSdigital/ssdc-rm-acceptance-tests/pull/28) to test there is no regression.


- Tag and push the docker image to your GCP env and deploy it.
- Load a sample. This should be a big sample that takes over 10 minutes to load. The chrome dev tools network throttling utility helps with this. 
- Wait for the sample load to be successful!
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/wx7CEHqo/2594-massive-sample-file-upload-fails-due-to-jwt-token-expiry
# Screenshots (if appropriate):
