### PR TITLE
Use shared project for shared pubsub topics and subscriptions

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/Application.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/Application.java
@@ -2,8 +2,11 @@ package uk.gov.ons.ssdc.supporttool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubReactiveAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = {GcpPubSubAutoConfiguration.class, GcpPubSubReactiveAutoConfiguration.class})
 public class Application {
   public static void main(String[] args) {
     SpringApplication.run(Application.class, args);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/AppConfig.java
@@ -2,9 +2,6 @@ package uk.gov.ons.ssdc.supporttool.config;
 
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
-import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,16 +11,6 @@ import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
 @Configuration
 @EnableScheduling
 public class AppConfig {
-  @Bean
-  public PubSubTemplate pubSubTemplate(
-      PublisherFactory publisherFactory,
-      SubscriberFactory subscriberFactory,
-      JacksonPubSubMessageConverter jacksonPubSubMessageConverter) {
-    PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
-    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverter);
-    return pubSubTemplate;
-  }
-
   @Bean
   public JacksonPubSubMessageConverter messageConverter() {
     return new JacksonPubSubMessageConverter(ObjectMapperFactory.objectMapper());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/OurProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/OurProjectPubsubConfig.java
@@ -1,0 +1,100 @@
+package uk.gov.ons.ssdc.supporttool.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubProperties;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OurProjectPubsubConfig {
+  @Value("${queueconfig.our-pubsub-project}")
+  private String ourPubsubProject;
+
+  private final GcpPubSubProperties gcpPubSubProperties;
+
+  public OurProjectPubsubConfig(GcpPubSubProperties gcpPubSubProperties) {
+    this.gcpPubSubProperties = gcpPubSubProperties;
+  }
+
+  @Bean("ourProjectPubSubSubscriberTemplate")
+  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
+      @Qualifier("ourProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
+    return new PubSubSubscriberTemplate(subscriberFactory);
+  }
+
+  @Bean("ourProjectPubSubPublisherTemplate")
+  public PubSubPublisherTemplate pubSubPublisherTemplate(
+      @Qualifier("ourProjectPublisherFactory") PublisherFactory publisherFactory) {
+    return new PubSubPublisherTemplate(publisherFactory);
+  }
+
+  @Bean("ourProjectPublisherFactory")
+  public DefaultPublisherFactory publisherFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("publisherTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultPublisherFactory defaultPublisherFactory =
+        new DefaultPublisherFactory(() -> ourPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
+    return defaultPublisherFactory;
+  }
+
+  @Bean("ourProjectSubscriberFactory")
+  public DefaultSubscriberFactory subscriberFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("subscriberTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultSubscriberFactory defaultSubscriberFactory =
+        new DefaultSubscriberFactory(() -> ourPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
+    return defaultSubscriberFactory;
+  }
+
+  @Bean(name = "ourProjectPubSubTemplate")
+  public PubSubTemplate pubSubTemplate(
+      @Qualifier("ourProjectPubSubPublisherTemplate")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("ourProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverter) {
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverter);
+    return pubSubTemplate;
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/SharedProjectPubsubConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/SharedProjectPubsubConfig.java
@@ -1,0 +1,100 @@
+package uk.gov.ons.ssdc.supporttool.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubProperties;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SharedProjectPubsubConfig {
+  @Value("${queueconfig.shared-pubsub-project}")
+  private String sharedPubsubProject;
+
+  private final GcpPubSubProperties gcpPubSubProperties;
+
+  public SharedProjectPubsubConfig(GcpPubSubProperties gcpPubSubProperties) {
+    this.gcpPubSubProperties = gcpPubSubProperties;
+  }
+
+  @Bean("sharedProjectPubSubSubscriberTemplate")
+  public PubSubSubscriberTemplate pubSubSubscriberTemplate(
+      @Qualifier("sharedProjectSubscriberFactory") SubscriberFactory subscriberFactory) {
+    return new PubSubSubscriberTemplate(subscriberFactory);
+  }
+
+  @Bean("sharedProjectPubSubPublisherTemplate")
+  public PubSubPublisherTemplate pubSubPublisherTemplate(
+      @Qualifier("sharedProjectPublisherFactory") PublisherFactory publisherFactory) {
+    return new PubSubPublisherTemplate(publisherFactory);
+  }
+
+  @Bean("sharedProjectPublisherFactory")
+  public DefaultPublisherFactory publisherFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("publisherTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultPublisherFactory defaultPublisherFactory =
+        new DefaultPublisherFactory(() -> sharedPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultPublisherFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultPublisherFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultPublisherFactory.setChannelProvider(transportChannelProvider);
+    return defaultPublisherFactory;
+  }
+
+  @Bean("sharedProjectSubscriberFactory")
+  public DefaultSubscriberFactory subscriberFactory(
+      CredentialsProvider credentialsProvider,
+      @Qualifier("subscriberTransportChannelProvider")
+          TransportChannelProvider transportChannelProvider) {
+    final DefaultSubscriberFactory defaultSubscriberFactory =
+        new DefaultSubscriberFactory(() -> sharedPubsubProject);
+
+    if (gcpPubSubProperties.getEmulatorHost() == null
+        || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+      defaultSubscriberFactory.setCredentialsProvider(credentialsProvider);
+    } else {
+      // Since we cannot create a general NoCredentialsProvider if the emulator host is enabled
+      // (because it would also be used for the other components), we have to create one here
+      // for this particular case.
+      defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    defaultSubscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
+    defaultSubscriberFactory.setChannelProvider(transportChannelProvider);
+    return defaultSubscriberFactory;
+  }
+
+  @Bean(name = "sharedProjectPubSubTemplate")
+  public PubSubTemplate pubSubTemplate(
+      @Qualifier("sharedProjectPubSubPublisherTemplate")
+          PubSubPublisherTemplate pubSubPublisherTemplate,
+      @Qualifier("sharedProjectPubSubSubscriberTemplate")
+          PubSubSubscriberTemplate pubSubSubscriberTemplate,
+      JacksonPubSubMessageConverter jacksonPubSubMessageConverter) {
+    PubSubTemplate pubSubTemplate =
+        new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
+    pubSubTemplate.setMessageConverter(jacksonPubSubMessageConverter);
+    return pubSubTemplate;
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/DeactivateUacEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/DeactivateUacEndpoint.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ssdc.supporttool.endpoint;
 import static uk.gov.ons.ssdc.supporttool.model.entity.UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE;
 
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.http.HttpStatus;
@@ -34,7 +35,7 @@ public class DeactivateUacEndpoint {
   public DeactivateUacEndpoint(
       UserIdentity userIdentity,
       UacQidLinkRepository qidLinkRepository,
-      PubSubTemplate pubSubTemplate) {
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     this.userIdentity = userIdentity;
     this.qidLinkRepository = qidLinkRepository;
     this.pubSubTemplate = pubSubTemplate;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
@@ -5,6 +5,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.stereotype.Component;
@@ -29,7 +30,9 @@ public class RowChunkProcessor {
   @Value("${queueconfig.sample-topic}")
   private String sampleTopic;
 
-  public RowChunkProcessor(JobRowRepository jobRowRepository, PubSubTemplate pubSubTemplate) {
+  public RowChunkProcessor(
+      JobRowRepository jobRowRepository,
+      @Qualifier("ourProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     this.jobRowRepository = jobRowRepository;
     this.pubSubTemplate = pubSubTemplate;
   }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ssdc.supporttool.service;
 
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,9 @@ public class CaseService {
   @Value("${queueconfig.update-sample-sensitive-topic}")
   private String updateSampleSenstiveTopic;
 
-  public CaseService(CaseRepository caseRepository, PubSubTemplate pubSubTemplate) {
+  public CaseService(
+      CaseRepository caseRepository,
+      @Qualifier("sharedProjectPubSubTemplate") PubSubTemplate pubSubTemplate) {
     this.caseRepository = caseRepository;
     this.pubSubTemplate = pubSubTemplate;
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,5 +72,7 @@ queueconfig:
   invalid-case-event-topic: event_invalid-case
   update-sample-sensitive-topic: event_update-sample-sensitive
   publishtimeout: 30  # In seconds
+  our-pubsub-project: our-project
+  shared-pubsub-project: shared-project
 
 file-upload-storage-path: /tmp/

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,4 +6,3 @@ spring:
     gcp:
       pubsub:
         emulator-host: localhost:18538
-        project-id: project


### PR DESCRIPTION
# Motivation and Context
RM doesn't 'own' the topics and subscriptions which are used to integrate between other products... and as such, they should be kept in a shared project.

# What has changed
Use our own project only for internal messaging, otherwise use a shared project.

# How to test?
Build Case Processor and Support Tool, then start everything up in docker dev with `make up` and then run the acceptance tests with `make test`... should be zero regression.

# Links
Trello: https://trello.com/c/yPZ72ten