### PR TITLE
Add auto pubsub config that was missing for GCP

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/PubsubTransportConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/PubsubTransportConfig.java
@@ -1,0 +1,30 @@
+package uk.gov.ons.ssdc.supporttool.config;
+
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.threeten.bp.Duration;
+
+@Configuration
+@Profile({"!test"})
+public class PubsubTransportConfig {
+  @Bean
+  @ConditionalOnMissingBean(name = "subscriberTransportChannelProvider")
+  public TransportChannelProvider subscriberTransportChannelProvider() {
+    return SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
+        .setKeepAliveTime(Duration.ofMinutes(5))
+        .build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(name = "publisherTransportChannelProvider")
+  public TransportChannelProvider publisherTransportChannelProvider() {
+    return PublisherStubSettings.defaultGrpcTransportProviderBuilder()
+        .setKeepAliveTime(Duration.ofMinutes(5))
+        .build();
+  }
+}


### PR DESCRIPTION
# Motivation and Context
The Google PubSub libraries are acting differently in GCP versus what they are on local machine, with the emulator.

# What has changed
Added config that was missing.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/yPZ72ten