### PR TITLE
Configure print suppliers via JSON file

### DIFF
--- a/dummy-print-supplier-config.json
+++ b/dummy-print-supplier-config.json
@@ -1,0 +1,10 @@
+{
+  "SUPPLIER_A": {
+    "sftpDirectory": "foo",
+    "encryptionKeyFilename": "bar"
+  },
+  "SUPPLIER_B": {
+    "sftpDirectory": "foo",
+    "encryptionKeyFilename": "bar"
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,7 +64,7 @@ iapaudience: DUMMY
 # TODO: Remove this before releasing to prod
 dummyuseridentity: dummy@fake-email.com
 
-printsupplierconfig: '{"SUPPLIER_A":{"sftpDirectory":"foo","encryptionKeyFilename": "bar"},"SUPPLIER_B":{"sftpDirectory":"foo","encryptionKeyFilename":"bar"}}'
+printsupplierconfigfile: dummy-print-supplier-config.json
 
 queueconfig:
   sample-topic: rm-internal-sample


### PR DESCRIPTION
# Motivation and Context
The list of print suppliers should be globally configured via the K8S configmap file, which is JSON format.

# What has changed
Ripped out the hacked JSON config held in `application.yml` and replaced with file-based config, mounted by Docker/K8S.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/W9SX2a5n