### PR TITLE
Preserve correlation ID and originating user across events

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/Sample.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/Sample.java
@@ -13,4 +13,7 @@ public class Sample {
   private Map<String, String> sample;
 
   private Map<String, String> sampleSensitive;
+
+  private UUID jobId;
+  private String originatingUser;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/SampleTransformer.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/SampleTransformer.java
@@ -31,6 +31,9 @@ public class SampleTransformer implements Transformer {
 
     sample.setSample(nonSensitiveSampleData);
     sample.setSampleSensitive(sensitiveSampleData);
+
+    sample.setJobId(job.getId());
+    sample.setOriginatingUser(job.getCreatedBy());
     return sample;
   }
 }


### PR DESCRIPTION
# Motivation and Context
Correlation IDs are incredibly useful for audit trail, digital forensics, debugging and diagnosing defects, "identifying training opportunities" and suchlike. They only work if they truly correlate related events together, end-to-end.

Likewise, having an audit trail of the originating user - where it's known - is useful too, and saves a lot of hassle trawling through load balancer logs, trying to figure out who initiated a particular chain of events.

# What has changed
Preserved the correlation ID and originating user, where it's known, across events and other cascading effects from the original cause.

# How to test?
Use the support tool to create various types of event (e.g. refusal, receipt etc) and check that the resulting case and UAC updates have the correlation ID on them, and originating user (where appropriate).

# Links
Trello: https://trello.com/c/ESjv6BOa