### PR TITLE
Fix UTC/BST time mixup, for fulfilment triggers

### DIFF
--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -104,20 +104,28 @@ class LandingPage extends Component {
     this.setState({ surveys: surveyJson._embedded.surveys });
   };
 
+  getDateTimeForDateTimePicker = (date) => {
+    date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+    return date.toJSON().slice(0, 16);
+  };
+
   getFulfilmentTrigger = async () => {
     const response = await fetch(
       `/api/fulfilmentNextTriggers/${this.state.triggerID}`
     );
 
     if (!response.ok) {
-      var dateNow = new Date();
-      dateNow.setMinutes(dateNow.getMinutes() - dateNow.getTimezoneOffset());
-      this.setState({ nextFulfilmentTriggerDateTime: dateNow.toJSON() });
+      this.setState({
+        nextFulfilmentTriggerDateTime: this.getDateTimeForDateTimePicker(
+          new Date()
+        ),
+      });
     } else {
       const fulfilmentNextTriggerJson = await response.json();
+      var dateOfTrigger = new Date(fulfilmentNextTriggerJson.triggerDateTime);
       this.setState({
         nextFulfilmentTriggerDateTime:
-          fulfilmentNextTriggerJson.triggerDateTime,
+          this.getDateTimeForDateTimePicker(dateOfTrigger),
       });
     }
   };


### PR DESCRIPTION
# Motivation and Context
Understanding time zone complexities is not easy. Intuitively, it might seem 'obvious' that all times in a user interface should be in 'local' time, but that's not true: when you are talking about a time in the future, you might be talking about a time in a different time zone than the the current local time zone, because of daylight saving.

Consider this particularly awful problem: setting the trigger date and time to 1:30am 27 March 2022, when should this trigger run? 1:30am GMT? That makes no sense because at 1am on 27 March 2022, the clocks spring forward to 2am... therefore 1:30am on that day does not exist!

# What has changed
Changed the fulfilment trigger dialog to display and use the time according to the user's local clock... currently BST as of 8th September 2021. When daylight saving ends, the UI will automatically start displaying the time as GMT (UTC) instead.

# How to test?
Try setting the fulfilment trigger and check that it triggers when you expect it to. Then, change your clock to be no longer using daylight saving time, and check that it still works as expected.

# Links
Trello: https://trello.com/c/YwV2cPQK