### PR TITLE
Record user who quarantined message for audit trail

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/client/ExceptionManagerClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/client/ExceptionManagerClient.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.SkipMessageRequest;
 
 @Component
 public class ExceptionManagerClient {
@@ -49,13 +50,12 @@ public class ExceptionManagerClient {
     return result;
   }
 
-  public void skipMessage(String messageHash) {
+  public void skipMessage(SkipMessageRequest skipMessageRequest) {
 
     RestTemplate restTemplate = new RestTemplate();
-    UriComponents uriComponents =
-        createUriComponents(String.format("/skipmessage/%s", messageHash));
+    UriComponents uriComponents = createUriComponents("/skipmessage");
 
-    restTemplate.getForObject(uriComponents.toUri(), String.class);
+    restTemplate.postForObject(uriComponents.toUri(), skipMessageRequest, Void.class);
   }
 
   private UriComponents createUriComponents(String path) {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManager.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.client.ExceptionManagerClient;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.SkipMessageRequest;
 import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
 @Controller
@@ -56,7 +57,10 @@ public class ExceptionManager {
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
 
-    exceptionManagerClient.skipMessage(messageHash);
+    SkipMessageRequest skipMessageRequest = new SkipMessageRequest();
+    skipMessageRequest.setMessageHash(messageHash);
+    skipMessageRequest.setSkippingUser(userEmail);
+    exceptionManagerClient.skipMessage(skipMessageRequest);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/SkipMessageRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/SkipMessageRequest.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
+
+import lombok.Data;
+
+@Data
+public class SkipMessageRequest {
+  private String messageHash;
+  private String skippingUser;
+}


### PR DESCRIPTION
# Motivation and Context
We want an audit trail of who quarantined messages.

# What has changed
Did a best attempt at linking the user who originally requested that a message be 'skipped' to the eventual implementation of that request by the Exception Manager. User is recorded in a `skipping_user` database column in the `quarantined_message` table.

# How to test?
Create a bad message, either using the docker dev `publish_message.sh` script locally, or by publishing directly to a topic in GCP. Then, use the support tool to skip a message. Also, try skipping a message using the toolbox bad message wizard. Check the database - it should have recorded the user who skipped the message!

# Links
Trello: https://trello.com/c/JNPHZeos