### PR TITLE
Revoke activity permissions and remove users from groups

### DIFF
--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -10,6 +10,9 @@ import {
   FormControl,
   InputLabel,
   Select,
+  DialogTitle,
+  DialogContentText,
+  DialogActions,
 } from "@material-ui/core";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -28,9 +31,12 @@ class GroupDetails extends Component {
     allActivities: [],
     allSurveys: [],
     showAllowDialog: false,
+    showRemoveDialog: false,
     activity: null,
     activityValidationError: false,
     surveyId: null,
+    surveyName: null,
+    userGroupPermissionId: null,
   };
 
   componentDidMount() {
@@ -103,6 +109,7 @@ class GroupDetails extends Component {
       groupActivities.push({
         activity: activity,
         surveyName: surveyName,
+        userGroupPermissionId: userGroupPermissionId,
       });
     }
 
@@ -155,6 +162,31 @@ class GroupDetails extends Component {
     this.setState({
       showAllowDialog: false,
     });
+  };
+
+  openRemoveDialog = (activity, surveyName, userGroupPermissionId) => {
+    this.setState({
+      showRemoveDialog: true,
+      activity: activity,
+      surveyName: surveyName,
+      userGroupPermissionId: userGroupPermissionId,
+    });
+  };
+
+  closeRemoveDialog = () => {
+    this.setState({
+      showRemoveDialog: false,
+    });
+  };
+
+  removeActivityPermission = async () => {
+    await fetch(
+      `/api/userGroupPermissions/${this.state.userGroupPermissionId}`,
+      {
+        method: "DELETE",
+      }
+    );
+    this.closeRemoveDialog();
   };
 
   onActivityChange = (event) => {
@@ -215,6 +247,20 @@ class GroupDetails extends Component {
             <TableCell component="th" scope="row">
               {groupActivity.surveyName}
             </TableCell>
+            <TableCell component="th" scope="row">
+              <Button
+                variant="contained"
+                onClick={() =>
+                  this.openRemoveDialog(
+                    groupActivity.activity,
+                    groupActivity.surveyName,
+                    groupActivity.userGroupPermissionId
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </TableCell>
           </TableRow>
         );
       }
@@ -263,6 +309,7 @@ class GroupDetails extends Component {
                   <TableRow>
                     <TableCell>Activity</TableCell>
                     <TableCell>Survey</TableCell>
+                    <TableCell></TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>{groupActivitiesTableRows}</TableBody>
@@ -310,6 +357,29 @@ class GroupDetails extends Component {
                   </Button>
                 </div>
               </DialogContent>
+            </Dialog>
+            <Dialog open={this.state.showRemoveDialog}>
+              <DialogTitle id="alert-dialog-title">
+                {"Confirm remove?"}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  Are you sure you wish to remove activity: "
+                  {this.state.activity}" for survey: "{this.state.surveyName}"?
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.removeActivityPermission} color="primary">
+                  Yes
+                </Button>
+                <Button
+                  onClick={this.closeRemoveDialog}
+                  color="primary"
+                  autoFocus
+                >
+                  No
+                </Button>
+              </DialogActions>
             </Dialog>
           </>
         )}

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -10,6 +10,9 @@ import {
   FormControl,
   InputLabel,
   Select,
+  DialogTitle,
+  DialogContentText,
+  DialogActions,
 } from "@material-ui/core";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -29,6 +32,9 @@ class UserDetails extends Component {
     showGroupDialog: false,
     groupId: null,
     groupValidationError: false,
+    showRemoveDialog: false,
+    groupName: null,
+    userGroupMemberId: null,
   };
 
   componentDidMount() {
@@ -102,6 +108,7 @@ class UserDetails extends Component {
       groupMemberships.push({
         groupId: groupId,
         name: group.name,
+        userGroupMemberId: userGroupMemberId,
       });
     }
 
@@ -134,6 +141,27 @@ class UserDetails extends Component {
     this.setState({
       showGroupDialog: false,
     });
+  };
+
+  openRemoveDialog = (groupName, userGroupMemberId) => {
+    this.setState({
+      showRemoveDialog: true,
+      groupName: groupName,
+      userGroupMemberId: userGroupMemberId,
+    });
+  };
+
+  closeRemoveDialog = () => {
+    this.setState({
+      showRemoveDialog: false,
+    });
+  };
+
+  removeGroup = async () => {
+    await fetch(`/api/userGroupMembers/${this.state.userGroupMemberId}`, {
+      method: "DELETE",
+    });
+    this.closeRemoveDialog();
   };
 
   onGroupChange = (event) => {
@@ -176,6 +204,19 @@ class UserDetails extends Component {
                 {memberOfGroup.name}
               </Link>
             </TableCell>
+            <TableCell component="th" scope="row">
+              <Button
+                variant="contained"
+                onClick={() =>
+                  this.openRemoveDialog(
+                    memberOfGroup.name,
+                    memberOfGroup.userGroupMemberId
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </TableCell>
           </TableRow>
         );
       }
@@ -215,6 +256,7 @@ class UserDetails extends Component {
                 <TableHead>
                   <TableRow>
                     <TableCell>Group Name</TableCell>
+                    <TableCell></TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>{memberOfGroupTableRows}</TableBody>
@@ -253,6 +295,29 @@ class UserDetails extends Component {
                   </Button>
                 </div>
               </DialogContent>
+            </Dialog>
+            <Dialog open={this.state.showRemoveDialog}>
+              <DialogTitle id="alert-dialog-title">
+                {"Confirm remove?"}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  Are you sure you wish to remove group: "{this.state.groupName}
+                  " from this user?
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.removeGroup} color="primary">
+                  Yes
+                </Button>
+                <Button
+                  onClick={this.closeRemoveDialog}
+                  color="primary"
+                  autoFocus
+                >
+                  No
+                </Button>
+              </DialogActions>
             </Dialog>
           </>
         )}


### PR DESCRIPTION
# Motivation and Context
We need the ability to revoke permissions from groups and group permissions from users

# What has changed
User details screen: Each permission has a remove button next to it.  When you click it, you'll be asked to confirm before the permission is removed.

Group details screen: Each permission has a remove button next to it.  When you click it, you'll be asked to confirm before the permission is removed.

# How to test?
Add some activity permissions into a group.  Click the remove button to remove it.

Add some group permissions to a user.  Click the remove button to remove the group.

You should be given the chance to back out before any permissions are removed.

# Links
https://trello.com/c/J7WZc0IL
