### PR TITLE
2795 support tool case search special chars causes errors

### DIFF
--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -78,10 +78,6 @@ class SurveyCaseSearch extends Component {
     });
   };
 
-  checkWhitespace = (valueToValidate) => {
-    return valueToValidate.trim();
-  };
-
   isNumeric = (str) => {
     return /^\+?\d+$/.test(str);
   };
@@ -169,7 +165,6 @@ class SurveyCaseSearch extends Component {
             style={borderStyles}
             surveyId={this.props.surveyId}
             onSearchExecuteAndPopulateList={this.onSearchExecuteAndPopulateList}
-            searchTermValidator={this.checkWhitespace}
             collectionExercises={this.state.collectionExercises}
           />
         </div>

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -65,7 +65,7 @@ class SurveyCaseSearch extends Component {
 
     // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
     if (!response.ok) {
-      alert(`Error: ${response.state}`);
+      alert(`Error: ${response.statusText}`);
       return;
     }
 

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -49,7 +49,7 @@ class SurveySampleSearch extends Component {
   onSearch = async () => {
     this.setState({ searchTerm: this.state.searchTerm.trim() })
 
-    if (!/^[ A-Za-z0-9@.'-]*$/.test(this.state.searchTerm)) {
+    if (!/^[ A-Za-z0-9@.'-£$!]*$/.test(this.state.searchTerm)) {
       this.setState({ searchTermFailedValidation: true });
       return;
     }
@@ -246,7 +246,7 @@ class SurveySampleSearch extends Component {
           <Dialog open={true} maxWidth={300}>
             <DialogContent style={{ padding: 30 }}>
 
-              <p>Only Letters numbers and @'-. can be searched for</p>
+              <p>Only Letters numbers and @'-.!£$ can be searched for</p>
               <div>
                 <Button
                   onClick={this.closeInvalideSearchDialog}

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -9,6 +9,8 @@ import {
   MenuItem,
   Typography,
   Box,
+  Dialog,
+  DialogContent,
 } from "@material-ui/core";
 
 const SEARCH_FIELD_WIDTH = 200;
@@ -24,6 +26,7 @@ class SurveySampleSearch extends Component {
     selectedInvalidFilter: "",
     selectedLaunchedFilter: "",
     searchTerm: "",
+    searchTermFailedValidation: false
   };
 
   componentDidMount() {
@@ -43,25 +46,15 @@ class SurveySampleSearch extends Component {
     });
   };
 
-  stripWhiteSpaceAndValidate = () => {
-
+  onSearch = async () => {
     this.setState({ searchTerm: this.state.searchTerm.trim() })
 
-    if (/^[ A-Za-z0-9_@.&-]*$/.test(this.state.searchTerm)) {
-      this.setState({ searchTermFailedValidation: false });
+    if (!/^[ A-Za-z0-9@.'-]*$/.test(this.state.searchTerm)) {
+      this.setState({ searchTermFailedValidation: true });
       return;
     }
 
-    alert('Failed validation, allowed chars = x, y & z');
-    this.setState({ searchTermFailedValidation: true });
-
-  };
-
-
-  onSearch = async () => {
-
-    this.stripWhiteSpaceAndValidate();
-
+    this.setState({ searchTermFailedValidation: false });
 
     let searchUrl = `/api/surveyCases/${this.props.surveyId}?searchTerm=${this.state.searchTerm}`;
 
@@ -120,6 +113,10 @@ class SurveySampleSearch extends Component {
       selectedLaunchedFilter: event.target.value,
     });
   };
+
+  closeInvalideSearchDialog = () => {
+    this.setState({ searchTermFailedValidation: false });
+  }
 
   render() {
     const noFilterMenuItem = (
@@ -245,6 +242,23 @@ class SurveySampleSearch extends Component {
             </Select>
           </FormControl>
         </div>
+        {this.state.searchTermFailedValidation && (
+          <Dialog open={true} maxWidth={300}>
+            <DialogContent style={{ padding: 30 }}>
+
+              <p>Only Letters numbers and @'-. can be searched for</p>
+              <div>
+                <Button
+                  onClick={this.closeInvalideSearchDialog}
+                  variant="contained"
+                  style={{ margin: 10 }}
+                >
+                  Close
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
       </div>
     );
   }

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -26,7 +26,7 @@ class SurveySampleSearch extends Component {
     selectedInvalidFilter: "",
     selectedLaunchedFilter: "",
     searchTerm: "",
-    searchTermFailedValidation: false
+    searchTermFailedValidation: false,
   };
 
   componentDidMount() {
@@ -47,7 +47,7 @@ class SurveySampleSearch extends Component {
   };
 
   onSearch = async () => {
-    this.setState({ searchTerm: this.state.searchTerm.trim() })
+    this.setState({ searchTerm: this.state.searchTerm.trim() });
 
     if (!/^[ A-Za-z0-9@.'-£$!]*$/.test(this.state.searchTerm)) {
       this.setState({ searchTermFailedValidation: true });
@@ -116,7 +116,7 @@ class SurveySampleSearch extends Component {
 
   closeInvalideSearchDialog = () => {
     this.setState({ searchTermFailedValidation: false });
-  }
+  };
 
   render() {
     const noFilterMenuItem = (
@@ -245,7 +245,6 @@ class SurveySampleSearch extends Component {
         {this.state.searchTermFailedValidation && (
           <Dialog open={true} maxWidth={300}>
             <DialogContent style={{ padding: 30 }}>
-
               <p>Only Letters numbers and @'-.!£$ can be searched for</p>
               <div>
                 <Button

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -49,14 +49,14 @@ class SurveySampleSearch extends Component {
   onSearch = async () => {
     this.setState({ searchTerm: this.state.searchTerm.trim() });
 
-    if (!/^[ A-Za-z0-9@.'-£$!]*$/.test(this.state.searchTerm)) {
+    if (!/^[ a-z0-9@\'£$!&.-]+$/i.test(this.state.searchTerm)) {
       this.setState({ searchTermFailedValidation: true });
       return;
     }
 
     this.setState({ searchTermFailedValidation: false });
 
-    let searchUrl = `/api/surveyCases/${this.props.surveyId}?searchTerm=${this.state.searchTerm}`;
+    let searchUrl = `/api/surveyCases/${this.props.surveyId}?searchTerm=${encodeURIComponent(this.state.searchTerm)}`;
 
     if (this.state.selectedCollectionExercise) {
       searchUrl += `&collexId=${this.state.selectedCollectionExercise}`;
@@ -245,7 +245,7 @@ class SurveySampleSearch extends Component {
         {this.state.searchTermFailedValidation && (
           <Dialog open={true} maxWidth={300}>
             <DialogContent style={{ padding: 30 }}>
-              <p>Only Letters numbers and @'-.!£$ can be searched for</p>
+              <p>Only Letters numbers and @'-.!£$& can be searched for</p>
               <div>
                 <Button
                   onClick={this.closeInvalideSearchDialog}

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -56,7 +56,9 @@ class SurveySampleSearch extends Component {
 
     this.setState({ searchTermFailedValidation: false });
 
-    let searchUrl = `/api/surveyCases/${this.props.surveyId}?searchTerm=${encodeURIComponent(this.state.searchTerm)}`;
+    let searchUrl = `/api/surveyCases/${
+      this.props.surveyId
+    }?searchTerm=${encodeURIComponent(this.state.searchTerm)}`;
 
     if (this.state.selectedCollectionExercise) {
       searchUrl += `&collexId=${this.state.selectedCollectionExercise}`;

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -43,12 +43,26 @@ class SurveySampleSearch extends Component {
     });
   };
 
-  onSearch = async () => {
-    if (!this.props.searchTermValidator(this.state.searchTerm)) {
-      this.setState({ searchTermFailedValidation: true });
+  stripWhiteSpaceAndValidate = () => {
+
+    this.setState({ searchTerm: this.state.searchTerm.trim() })
+
+    if (/^[ A-Za-z0-9_@.&-]*$/.test(this.state.searchTerm)) {
+      this.setState({ searchTermFailedValidation: false });
       return;
     }
-    this.setState({ searchTermFailedValidation: false });
+
+    alert('Failed validation, allowed chars = x, y & z');
+    this.setState({ searchTermFailedValidation: true });
+
+  };
+
+
+  onSearch = async () => {
+
+    this.stripWhiteSpaceAndValidate();
+
+
     let searchUrl = `/api/surveyCases/${this.props.surveyId}?searchTerm=${this.state.searchTerm}`;
 
     if (this.state.selectedCollectionExercise) {

--- a/ui/src/SurveySimpleSearchInput.js
+++ b/ui/src/SurveySimpleSearchInput.js
@@ -8,7 +8,7 @@ class SurveySimpleSearchInput extends Component {
     failedValidation: false,
   };
 
-  componentDidMount() {}
+  componentDidMount() { }
 
   onChange = (event) => {
     this.setState({
@@ -17,6 +17,7 @@ class SurveySimpleSearchInput extends Component {
   };
 
   onSearch = async () => {
+
     if (!this.props.searchTermValidator(this.state.searchTerm)) {
       this.setState({ failedValidation: true });
       return;

--- a/ui/src/SurveySimpleSearchInput.js
+++ b/ui/src/SurveySimpleSearchInput.js
@@ -8,7 +8,7 @@ class SurveySimpleSearchInput extends Component {
     failedValidation: false,
   };
 
-  componentDidMount() { }
+  componentDidMount() {}
 
   onChange = (event) => {
     this.setState({
@@ -17,7 +17,6 @@ class SurveySimpleSearchInput extends Component {
   };
 
   onSearch = async () => {
-
     if (!this.props.searchTermValidator(this.state.searchTerm)) {
       this.setState({ failedValidation: true });
       return;


### PR DESCRIPTION
# Motivation and Context
Limit search terms

# What has changed
New shiny regex, removed probably wrong previous validation/whitespace trimmer

# How to test?
Load a survey with various special chars in.  You should only be able to search for:  A-Za-z0-9@.'-

# Links
https://trello.com/c/4BHMe8Sz/2795-support-tool-case-search-special-chars-causes-errors-5

