### PR TITLE
Add createdBy Column to Action Rule Table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.1.0-SNAPSHOT</version>
+      <version>2.2.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -47,8 +47,7 @@ public class ActionRuleEndpoint {
       @Value("#{request.getAttribute('userEmail')}") String createdBy) {
 
     Optional<CollectionExercise> collexExercise =
-        collectionExerciseRepository.findById(
-            UUID.fromString(actionRuleDTO.getCollectionExerciseId()));
+        collectionExerciseRepository.findById(actionRuleDTO.getCollectionExerciseId());
 
     if (!collexExercise.isPresent()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Collection exercise not found");

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -1,0 +1,81 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.ActionRuleDTO;
+import uk.gov.ons.ssdc.supporttool.model.repository.ActionRuleRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.CollectionExerciseRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/actionRules")
+public class ActionRuleEndpoint {
+
+  private final ActionRuleRepository actionRuleRepository;
+  private final UserIdentity userIdentity;
+  private final CollectionExerciseRepository collectionExerciseRepository;
+  private final PrintTemplateRepository printTemplateRepository;
+
+  public ActionRuleEndpoint(
+      ActionRuleRepository actionRuleRepository,
+      UserIdentity userIdentity,
+      CollectionExerciseRepository collectionExerciseRepository,
+      PrintTemplateRepository printTemplateRepository) {
+    this.actionRuleRepository = actionRuleRepository;
+    this.userIdentity = userIdentity;
+    this.collectionExerciseRepository = collectionExerciseRepository;
+    this.printTemplateRepository = printTemplateRepository;
+  }
+
+  @PostMapping
+  @Transactional
+  public void insertActionRules(
+      @RequestBody() ActionRuleDTO actionRuleDTO,
+      @Value("#{request.getAttribute('userEmail')}") String createdBy) {
+
+    Optional<CollectionExercise> collexExercise =
+        collectionExerciseRepository.findById(
+            UUID.fromString(actionRuleDTO.getCollectionExerciseId()));
+
+    if (!collexExercise.isPresent()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Collection exercise not found");
+    }
+
+    userIdentity.checkUserPermission(
+        createdBy,
+        collexExercise.get().getSurvey(),
+        UserGroupAuthorisedActivityType.CREATE_PRINT_ACTION_RULE);
+
+    PrintTemplate printTemplate =
+        printTemplateRepository
+            .findById(actionRuleDTO.getPackCode())
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "Print template not found"));
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setClassifiers(actionRuleDTO.getClassifiers());
+    actionRule.setPrintTemplate(printTemplate);
+    actionRule.setCollectionExercise(collexExercise.get());
+    actionRule.setType(actionRuleDTO.getType());
+    actionRule.setTriggerDateTime(actionRuleDTO.getTriggerDateTime());
+    actionRule.setCreatedBy(createdBy);
+
+    actionRuleRepository.save(actionRule);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -79,22 +79,18 @@ public class ActionRuleEndpoint {
         throw new IllegalStateException("Unexpected value: " + actionRuleDTO.getType());
     }
 
-    userIdentity.checkUserPermission(
-        createdBy,
-        collexExercise.get().getSurvey(),
-        userActivity);
+    userIdentity.checkUserPermission(createdBy, collexExercise.get().getSurvey(), userActivity);
 
-    if (actionRuleDTO.getPackCode().isEmpty() && actionRuleDTO.getType().equals(ActionRuleType.PRINT)) {
-      throw new IllegalStateException("There must be a Pack Code for a PRINT action rule!");
+    PrintTemplate printTemplate = null;
+    if (actionRuleDTO.getType().equals(ActionRuleType.PRINT)) {
+      printTemplate =
+          printTemplateRepository
+              .findById(actionRuleDTO.getPackCode())
+              .orElseThrow(
+                  () ->
+                      new ResponseStatusException(
+                          HttpStatus.BAD_REQUEST, "Print template not found"));
     }
-
-    PrintTemplate printTemplate =
-        printTemplateRepository
-            .findById(actionRuleDTO.getPackCode())
-            .orElseThrow(
-                () ->
-                    new ResponseStatusException(
-                        HttpStatus.BAD_REQUEST, "Print template not found"));
 
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,7 +43,7 @@ public class ActionRuleEndpoint {
 
   @PostMapping
   @Transactional
-  public void insertActionRules(
+  public ResponseEntity<UUID> insertActionRules(
       @RequestBody() ActionRuleDTO actionRuleDTO,
       @Value("#{request.getAttribute('userEmail')}") String createdBy) {
 
@@ -75,6 +76,8 @@ public class ActionRuleEndpoint {
     actionRule.setTriggerDateTime(actionRuleDTO.getTriggerDateTime());
     actionRule.setCreatedBy(createdBy);
 
-    actionRuleRepository.save(actionRule);
+    actionRuleRepository.saveAndFlush(actionRule);
+
+    return new ResponseEntity<>(actionRule.getId(), HttpStatus.CREATED);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
@@ -64,8 +64,8 @@ public class CaseEndpoint {
         validateFieldToUpdate(caze, updateSampleSensitive.getSampleSensitive());
 
     if (validationErrors.size() > 0) {
-      String validatationErrorStr = String.join(", ", validationErrors);
-      Map<String, String> body = Map.of("errors", validatationErrorStr);
+      String validationErrorStr = String.join(", ", validationErrors);
+      Map<String, String> body = Map.of("errors", validationErrorStr);
 
       return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
     }
@@ -185,14 +185,14 @@ public class CaseEndpoint {
     payload.setSmsFulfilment(smsFulfilment);
     smsFulfilmentRequest.setPayload(payload);
 
-    Optional<String> errorOpt = requestSmsFulfiment(smsFulfilmentRequest);
+    Optional<String> errorOpt = requestSmsFulfilment(smsFulfilmentRequest);
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
     }
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
-  private Optional<String> requestSmsFulfiment(RequestDTO smsFulfilmentRequest) {
+  private Optional<String> requestSmsFulfilment(RequestDTO smsFulfilmentRequest) {
     try {
       notifyServiceClient.requestSmsFulfilment(smsFulfilmentRequest);
     } catch (HttpClientErrorException e) {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
@@ -1,13 +1,14 @@
 package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.Data;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
 
 @Data
 public class ActionRuleDTO {
 
-  private String collectionExerciseId;
+  private UUID collectionExerciseId;
 
   private String packCode;
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
+
+import java.time.OffsetDateTime;
+import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
+
+@Data
+public class ActionRuleDTO {
+
+  private String collectionExerciseId;
+
+  private String packCode;
+
+  private String classifiers;
+
+  private ActionRuleType type;
+
+  private OffsetDateTime triggerDateTime;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleRepository.java
@@ -1,9 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.ActionRule;
 
 @RepositoryRestResource
-public interface ActionRuleRepository extends PagingAndSortingRepository<ActionRule, UUID> {}
+public interface ActionRuleRepository extends JpaRepository<ActionRule, UUID> {}

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -175,6 +175,11 @@ class CollectionExerciseDetails extends Component {
       return;
     }
 
+    let printTemplate = null;
+    if (this.state.newActionRuleType === "PRINT") {
+      printTemplate = "printTemplates/" + this.state.newActionRulePackCode;
+    }
+
     const newActionRule = {
       type: this.state.newActionRuleType,
       triggerDateTime: new Date(
@@ -182,6 +187,7 @@ class CollectionExerciseDetails extends Component {
       ).toISOString(),
       classifiers: this.state.newActionRuleClassifiers,
       packCode: this.state.newActionRulePackCode,
+      printTemplate: printTemplate,
       collectionExerciseId: this.props.collectionExerciseId,
     };
 

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -175,22 +175,14 @@ class CollectionExerciseDetails extends Component {
       return;
     }
 
-    let printTemplate = null;
-    if (this.state.newActionRuleType === "PRINT") {
-      printTemplate = "printTemplates/" + this.state.newActionRulePackCode;
-    }
-
     const newActionRule = {
-      id: uuidv4(),
       type: this.state.newActionRuleType,
       triggerDateTime: new Date(
         this.state.newActionRuleTriggerDate
       ).toISOString(),
-      hasTriggered: false,
       classifiers: this.state.newActionRuleClassifiers,
-      printTemplate: printTemplate,
-      collectionExercise:
-        "collectionExercises/" + this.props.collectionExerciseId,
+      packCode: this.state.newActionRulePackCode,
+      collectionExerciseId: this.props.collectionExerciseId,
     };
 
     const response = await fetch("/api/actionRules", {

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -18,7 +18,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { uuidv4 } from "./common";
 import SampleUpload from "./SampleUpload";
 import { getActionRulePrintTemplates } from "./Utils";
 import { Link } from "react-router-dom";
@@ -175,9 +174,10 @@ class CollectionExerciseDetails extends Component {
       return;
     }
 
-    let printTemplate = null;
+    let printTemplatePackCode = "";
+
     if (this.state.newActionRuleType === "PRINT") {
-      printTemplate = "printTemplates/" + this.state.newActionRulePackCode;
+      printTemplatePackCode = this.state.newActionRulePackCode;
     }
 
     const newActionRule = {
@@ -186,8 +186,7 @@ class CollectionExerciseDetails extends Component {
         this.state.newActionRuleTriggerDate
       ).toISOString(),
       classifiers: this.state.newActionRuleClassifiers,
-      packCode: this.state.newActionRulePackCode,
-      printTemplate: printTemplate,
+      packCode: printTemplatePackCode,
       collectionExerciseId: this.props.collectionExerciseId,
     };
 

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -267,7 +267,7 @@ class CollectionExerciseDetails extends Component {
       )
     ) {
       allowedActionRuleTypeMenuItems.push(
-        <MenuItem value={"OUTBOUND_PHONE"}>Outbound phone</MenuItem>
+        <MenuItem value={"OUTBOUND_TELEPHONE"}>Outbound phone</MenuItem>
       );
     }
     if (


### PR DESCRIPTION
# Motivation and Context
Need to add createdBy column to action_rule table to be able to keep an audit trail

# What has changed
New endpoint for posting action rules into database
New ActionRuleDTO
Updated CollectionExerciseDetails.js

# How to test?
Check the db for the createdBy column and check you can create an action rule

# Links
https://trello.com/c/m26JBFvw

# Screenshots (if appropriate):
<img width="1680" alt="Screenshot 2021-09-20 at 13 06 35" src="https://user-images.githubusercontent.com/38526889/133999375-5a554a79-044d-46d2-b11d-d52020069a46.png">
<img width="1680" alt="Screenshot 2021-09-20 at 13 06 44" src="https://user-images.githubusercontent.com/38526889/133999388-8d38d53f-805b-4976-b393-a284ea13b50d.png">

