### PR TITLE
Allow Action Rule to have SMS template and phone number column on it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.3.0-SNAPSHOT-sms-action-rule</version>
+      <version>2.3.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT-sms-action-rule</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -5,6 +5,7 @@ import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityTyp
 import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.CREATE_OUTBOUND_PHONE_ACTION_RULE;
 import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.CREATE_PRINT_ACTION_RULE;
 import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.CREATE_SMS_ACTION_RULE;
+import static uk.gov.ons.ssdc.supporttool.utility.SampleColumnHelper.getColumns;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -98,6 +99,11 @@ public class ActionRuleEndpoint {
                     () ->
                         new ResponseStatusException(
                             HttpStatus.BAD_REQUEST, "SMS template not found"));
+        if (!getColumns(collexExercise.get().getSurvey(), true)
+            .contains(actionRuleDTO.getPhoneNumberColumn())) {
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST, "Phone number column does not exist");
+        }
         break;
       default:
         throw new IllegalStateException("Unexpected value: " + actionRuleDTO.getType());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
-import static uk.gov.ons.ssdc.supporttool.utility.AllowPrintTemplateOnSurveyValidator.validate;
+import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveyPrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowPrintTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.ActionRuleSurveyPrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
@@ -37,22 +38,22 @@ public class ActionRuleSurveyPrintTemplateEndpoint {
 
   @PostMapping
   public ResponseEntity<String> createActionRuleSurveyPrintTemplate(
-      @RequestBody AllowPrintTemplateOnSurvey allowPrintTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
     Survey survey =
         surveyRepository
-            .findById(allowPrintTemplateOnSurvey.getSurveyId())
+            .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
 
     PrintTemplate printTemplate =
         printTemplateRepository
-            .findById(allowPrintTemplateOnSurvey.getPackCode())
+            .findById(allowTemplateOnSurvey.getPackCode())
             .orElseThrow(
                 () ->
                     new ResponseStatusException(
                         HttpStatus.BAD_REQUEST, "Print template not found"));
 
-    Optional<String> errorOpt = validate(survey, printTemplate);
+    Optional<String> errorOpt = validate(survey, Set.of(printTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
@@ -1,0 +1,69 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.repository.ActionRuleSurveySmsTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+
+@Controller
+@RequestMapping(value = "/api/actionRuleSurveySmsTemplates")
+public class ActionRuleSurveySmsTemplateEndpoint {
+  private final ActionRuleSurveySmsTemplateRepository actionRuleSurveySmsTemplateRepository;
+  private final SurveyRepository surveyRepository;
+  private final SmsTemplateRepository smsTemplateRepository;
+
+  public ActionRuleSurveySmsTemplateEndpoint(
+      ActionRuleSurveySmsTemplateRepository actionRuleSurveySmsTemplateRepository,
+      SurveyRepository surveyRepository,
+      SmsTemplateRepository smsTemplateRepository) {
+    this.actionRuleSurveySmsTemplateRepository = actionRuleSurveySmsTemplateRepository;
+    this.surveyRepository = surveyRepository;
+    this.smsTemplateRepository = smsTemplateRepository;
+  }
+
+  @PostMapping
+  public ResponseEntity<String> createActionRuleSurveySmsTemplate(
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+    Survey survey =
+        surveyRepository
+            .findById(allowTemplateOnSurvey.getSurveyId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    SmsTemplate smsTemplate =
+        smsTemplateRepository
+            .findById(allowTemplateOnSurvey.getPackCode())
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(HttpStatus.BAD_REQUEST, "SMS template not found"));
+
+    Optional<String> errorOpt = validate(survey, Set.of(smsTemplate.getTemplate()));
+    if (errorOpt.isPresent()) {
+      return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
+    }
+
+    ActionRuleSurveySmsTemplate actionRuleSurveySmsTemplate = new ActionRuleSurveySmsTemplate();
+    actionRuleSurveySmsTemplate.setId(UUID.randomUUID());
+    actionRuleSurveySmsTemplate.setSurvey(survey);
+    actionRuleSurveySmsTemplate.setSmsTemplate(smsTemplate);
+
+    actionRuleSurveySmsTemplateRepository.save(actionRuleSurveySmsTemplate);
+
+    return new ResponseEntity<>("OK", HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyPrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyPrintTemplateEndpoint.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
-import static uk.gov.ons.ssdc.supporttool.utility.AllowPrintTemplateOnSurveyValidator.validate;
+import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyPrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowPrintTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveyPrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
@@ -37,22 +38,22 @@ public class FulfilmentSurveyPrintTemplateEndpoint {
 
   @PostMapping
   public ResponseEntity<String> createFulfilmentSurveyPrintTemplate(
-      @RequestBody AllowPrintTemplateOnSurvey allowPrintTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
     Survey survey =
         surveyRepository
-            .findById(allowPrintTemplateOnSurvey.getSurveyId())
+            .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
 
     PrintTemplate printTemplate =
         printTemplateRepository
-            .findById(allowPrintTemplateOnSurvey.getPackCode())
+            .findById(allowTemplateOnSurvey.getPackCode())
             .orElseThrow(
                 () ->
                     new ResponseStatusException(
                         HttpStatus.BAD_REQUEST, "Print template not found"));
 
-    Optional<String> errorOpt = validate(survey, printTemplate);
+    Optional<String> errorOpt = validate(survey, Set.of(printTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/ActionRuleDTO.java
@@ -17,4 +17,6 @@ public class ActionRuleDTO {
   private ActionRuleType type;
 
   private OffsetDateTime triggerDateTime;
+
+  private String phoneNumberColumn;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/AllowTemplateOnSurvey.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/AllowTemplateOnSurvey.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-public class AllowPrintTemplateOnSurvey {
+public class AllowTemplateOnSurvey {
   private UUID surveyId;
   private String packCode;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.ssdc.supporttool.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveySmsTemplate;
+
+public interface ActionRuleSurveySmsTemplateRepository
+    extends PagingAndSortingRepository<ActionRuleSurveySmsTemplate, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/utility/SampleColumnHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/utility/SampleColumnHelper.java
@@ -1,5 +1,8 @@
 package uk.gov.ons.ssdc.supporttool.utility;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import uk.gov.ons.ssdc.common.model.entity.Job;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
@@ -19,5 +22,12 @@ public class SampleColumnHelper {
     }
 
     return expectedColumns;
+  }
+
+  public static Set<String> getColumns(Survey survey, boolean sensitive) {
+    return Arrays.stream(survey.getSampleValidationRules())
+        .filter(columnValidator -> columnValidator.isSensitive() == sensitive)
+        .map(columnValidator -> columnValidator.getColumnName())
+        .collect(Collectors.toSet());
   }
 }

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -19,20 +19,29 @@ import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import SampleUpload from "./SampleUpload";
-import { getActionRulePrintTemplates } from "./Utils";
+import {
+  getActionRulePrintTemplates,
+  getActionRuleSmsTemplates,
+} from "./Utils";
 import { Link } from "react-router-dom";
 
 class CollectionExerciseDetails extends Component {
   state = {
     authorisedActivities: [],
     actionRules: [],
-    packCodes: [],
+    printPackCodes: [],
     printTemplateHrefToPackCodeMap: new Map(),
+    smsPackCodes: [],
+    smsTemplateHrefToPackCodeMap: new Map(),
     createActionRulesDialogDisplayed: false,
-    packCodeValidationError: false,
+    printPackCodeValidationError: false,
+    smsPackCodeValidationError: false,
+    smsPhoneNumberColumnValidationError: false,
     actionRuleTypeValidationError: false,
     collectionExerciseName: "",
-    newActionRulePackCode: "",
+    newActionRulePrintPackCode: "",
+    newActionRuleSmsPackCode: "",
+    newActionRuleSmsPhoneNumberColumn: "",
     newActionRuleClassifiers: "",
     newActionRuleType: "",
   };
@@ -42,6 +51,7 @@ class CollectionExerciseDetails extends Component {
     this.getCollectionExerciseName();
     this.getActionRules();
     this.getPrintTemplates();
+    this.getSmsTemplates();
 
     this.interval = setInterval(() => this.getActionRules(), 1000);
   }
@@ -86,6 +96,7 @@ class CollectionExerciseDetails extends Component {
     const actionRules = actionRuleJson._embedded.actionRules;
 
     let printTemplateHrefToPackCodeMap = new Map();
+    let smsTemplateHrefToPackCodeMap = new Map();
 
     for (let i = 0; i < actionRules.length; i++) {
       if (actionRules[i].type === "PRINT") {
@@ -100,26 +111,45 @@ class CollectionExerciseDetails extends Component {
           actionRules[i]._links.printTemplate.href,
           packCode
         );
+      } else if (actionRules[i].type === "SMS") {
+        const smsTemplateUrl = new URL(actionRules[i]._links.smsTemplate.href);
+        const smsTemplateResponse = await fetch(smsTemplateUrl.pathname);
+        const smsTemplateJson = await smsTemplateResponse.json();
+        const packCode = smsTemplateJson._links.self.href.split("/").pop();
+
+        smsTemplateHrefToPackCodeMap.set(
+          actionRules[i]._links.smsTemplate.href,
+          packCode
+        );
       }
     }
 
     this.setState({
       actionRules: actionRules,
       printTemplateHrefToPackCodeMap: printTemplateHrefToPackCodeMap,
+      smsTemplateHrefToPackCodeMap: smsTemplateHrefToPackCodeMap,
     });
   };
 
   getPrintTemplates = async () => {
     const packCodes = await getActionRulePrintTemplates(this.props.surveyId);
-    this.setState({ packCodes: packCodes });
+    this.setState({ printPackCodes: packCodes });
+  };
+
+  getSmsTemplates = async () => {
+    const packCodes = await getActionRuleSmsTemplates(this.props.surveyId);
+    this.setState({ smsPackCodes: packCodes });
   };
 
   openDialog = () => {
     this.setState({
       newActionRuleType: "",
       actionRuleTypeValidationError: false,
-      newActionRulePackCode: "",
+      newActionRulePrintPackCode: "",
+      newActionRuleSmsPackCode: "",
+      newActionRuleSmsPhoneNumberColumn: "",
       packCodeValidationError: false,
+      smsPhoneNumberColumnValidationError: false,
       newActionRuleClassifiers: "",
       createActionRulesDialogDisplayed: true,
       newActionRuleTriggerDate: this.getTimeNowForDateTimePicker(),
@@ -130,10 +160,17 @@ class CollectionExerciseDetails extends Component {
     this.setState({ createActionRulesDialogDisplayed: false });
   };
 
-  onNewActionRulePackCodeChange = (event) => {
+  onNewActionRulePrintPackCodeChange = (event) => {
     this.setState({
-      packCodeValidationError: false,
-      newActionRulePackCode: event.target.value,
+      printPackCodeValidationError: false,
+      newActionRulePrintPackCode: event.target.value,
+    });
+  };
+
+  onNewActionRuleSmsPackCodeChange = (event) => {
+    this.setState({
+      smsPackCodeValidationError: false,
+      newActionRuleSmsPackCode: event.target.value,
     });
   };
 
@@ -154,6 +191,13 @@ class CollectionExerciseDetails extends Component {
     });
   };
 
+  onNewActionRuleSmsPhoneNumberChange = (event) => {
+    this.setState({
+      newActionRuleSmsPhoneNumberColumn: event.target.value,
+      smsPhoneNumberColumnValidationError: false,
+    });
+  };
+
   onCreateActionRule = async () => {
     var failedValidation = false;
 
@@ -163,10 +207,18 @@ class CollectionExerciseDetails extends Component {
     }
 
     if (
-      !this.state.newActionRulePackCode &&
+      !this.state.newActionRulePrintPackCode &&
       this.state.newActionRuleType === "PRINT"
     ) {
-      this.setState({ packCodeValidationError: true });
+      this.setState({ printPackCodeValidationError: true });
+      failedValidation = true;
+    }
+
+    if (
+      !this.state.newActionRuleSmsPackCode &&
+      this.state.newActionRuleType === "SMS"
+    ) {
+      this.setState({ smsPackCodeValidationError: true });
       failedValidation = true;
     }
 
@@ -174,10 +226,17 @@ class CollectionExerciseDetails extends Component {
       return;
     }
 
-    let printTemplatePackCode = "";
+    let newActionRulePackCode = "";
+    let newActionRuleSmsPhoneNumberColumn = null;
 
     if (this.state.newActionRuleType === "PRINT") {
-      printTemplatePackCode = this.state.newActionRulePackCode;
+      newActionRulePackCode = this.state.newActionRulePrintPackCode;
+    }
+
+    if (this.state.newActionRuleType === "SMS") {
+      newActionRulePackCode = this.state.newActionRuleSmsPackCode;
+      newActionRuleSmsPhoneNumberColumn =
+        this.state.newActionRuleSmsPhoneNumberColumn;
     }
 
     const newActionRule = {
@@ -186,8 +245,9 @@ class CollectionExerciseDetails extends Component {
         this.state.newActionRuleTriggerDate
       ).toISOString(),
       classifiers: this.state.newActionRuleClassifiers,
-      packCode: printTemplatePackCode,
+      packCode: newActionRulePackCode,
       collectionExerciseId: this.props.collectionExerciseId,
+      phoneNumberColumn: newActionRuleSmsPhoneNumberColumn,
     };
 
     const response = await fetch("/api/actionRules", {
@@ -216,6 +276,10 @@ class CollectionExerciseDetails extends Component {
           packCode = this.state.printTemplateHrefToPackCodeMap.get(
             actionRule._links.printTemplate.href
           );
+        } else if (actionRule.type === "SMS") {
+          packCode = this.state.smsTemplateHrefToPackCodeMap.get(
+            actionRule._links.smsTemplate.href
+          );
         }
 
         return (
@@ -240,7 +304,13 @@ class CollectionExerciseDetails extends Component {
       }
     );
 
-    const packCodeMenuItems = this.state.packCodes.map((packCode) => (
+    const printPackCodeMenuItems = this.state.printPackCodes.map((packCode) => (
+      <MenuItem key={packCode} value={packCode}>
+        {packCode}
+      </MenuItem>
+    ));
+
+    const smsPackCodeMenuItems = this.state.smsPackCodes.map((packCode) => (
       <MenuItem key={packCode} value={packCode}>
         {packCode}
       </MenuItem>
@@ -250,6 +320,11 @@ class CollectionExerciseDetails extends Component {
     if (this.state.authorisedActivities.includes("CREATE_PRINT_ACTION_RULE")) {
       allowedActionRuleTypeMenuItems.push(
         <MenuItem value={"PRINT"}>Print</MenuItem>
+      );
+    }
+    if (this.state.authorisedActivities.includes("CREATE_SMS_ACTION_RULE")) {
+      allowedActionRuleTypeMenuItems.push(
+        <MenuItem value={"SMS"}>SMS</MenuItem>
       );
     }
     if (
@@ -336,13 +411,36 @@ class CollectionExerciseDetails extends Component {
                   <FormControl required fullWidth={true}>
                     <InputLabel>Pack Code</InputLabel>
                     <Select
-                      onChange={this.onNewActionRulePackCodeChange}
-                      value={this.state.newActionRulePackCode}
-                      error={this.state.packCodeValidationError}
+                      onChange={this.onNewActionRulePrintPackCodeChange}
+                      value={this.state.newActionRulePrintPackCode}
+                      error={this.state.printPackCodeValidationError}
                     >
-                      {packCodeMenuItems}
+                      {printPackCodeMenuItems}
                     </Select>
                   </FormControl>
+                )}
+                {this.state.newActionRuleType === "SMS" && (
+                  <>
+                    <FormControl required fullWidth={true}>
+                      <InputLabel>Pack Code</InputLabel>
+                      <Select
+                        onChange={this.onNewActionRuleSmsPackCodeChange}
+                        value={this.state.newActionRuleSmsPackCode}
+                        error={this.state.smsPackCodeValidationError}
+                      >
+                        {smsPackCodeMenuItems}
+                      </Select>
+                    </FormControl>
+                    <TextField
+                      fullWidth={true}
+                      required
+                      style={{ marginTop: 20 }}
+                      error={this.state.smsPhoneNumberColumnValidationError}
+                      label="Phone Number Column"
+                      onChange={this.onNewActionRuleSmsPhoneNumberChange}
+                      value={this.state.newActionRuleSmsPhoneNumberColumn}
+                    />
+                  </>
                 )}
                 <TextField
                   fullWidth={true}

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -22,6 +22,7 @@ import SampleUpload from "./SampleUpload";
 import {
   getActionRulePrintTemplates,
   getActionRuleSmsTemplates,
+  getSensitiveSampleColumns,
 } from "./Utils";
 import { Link } from "react-router-dom";
 
@@ -31,6 +32,7 @@ class CollectionExerciseDetails extends Component {
     actionRules: [],
     printPackCodes: [],
     printTemplateHrefToPackCodeMap: new Map(),
+    sensitiveSampleColumns: [],
     smsPackCodes: [],
     smsTemplateHrefToPackCodeMap: new Map(),
     createActionRulesDialogDisplayed: false,
@@ -52,6 +54,7 @@ class CollectionExerciseDetails extends Component {
     this.getActionRules();
     this.getPrintTemplates();
     this.getSmsTemplates();
+    this.getSensitiveSampleColumns();
 
     this.interval = setInterval(() => this.getActionRules(), 1000);
   }
@@ -72,6 +75,11 @@ class CollectionExerciseDetails extends Component {
 
     this.setState({ authorisedActivities: authJson });
   };
+
+  getSensitiveSampleColumns = async () => {
+    const sensitiveSampleColumns = await getSensitiveSampleColumns(this.props.surveyId)
+    this.setState({ sensitiveSampleColumns: sensitiveSampleColumns });
+  }
 
   getCollectionExerciseName = async () => {
     const response = await fetch(
@@ -222,6 +230,14 @@ class CollectionExerciseDetails extends Component {
       failedValidation = true;
     }
 
+    if (
+      !this.state.newActionRuleSmsPhoneNumberColumn &&
+      this.state.newActionRuleType === "SMS"
+    ) {
+      this.setState({ smsPhoneNumberColumnValidationError: true });
+      failedValidation = true;
+    }
+
     if (failedValidation) {
       return;
     }
@@ -313,6 +329,12 @@ class CollectionExerciseDetails extends Component {
     const smsPackCodeMenuItems = this.state.smsPackCodes.map((packCode) => (
       <MenuItem key={packCode} value={packCode}>
         {packCode}
+      </MenuItem>
+    ));
+
+    const sensitiveSampleColumnsMenuItems = this.state.sensitiveSampleColumns.map((column) => (
+      <MenuItem key={column} value={column}>
+        {column}
       </MenuItem>
     ));
 
@@ -431,15 +453,16 @@ class CollectionExerciseDetails extends Component {
                         {smsPackCodeMenuItems}
                       </Select>
                     </FormControl>
-                    <TextField
-                      fullWidth={true}
-                      required
-                      style={{ marginTop: 20 }}
-                      error={this.state.smsPhoneNumberColumnValidationError}
-                      label="Phone Number Column"
-                      onChange={this.onNewActionRuleSmsPhoneNumberChange}
-                      value={this.state.newActionRuleSmsPhoneNumberColumn}
-                    />
+                    <FormControl required fullWidth={true}>
+                      <InputLabel>Phone Number Column</InputLabel>
+                      <Select
+                        onChange={this.onNewActionRuleSmsPhoneNumberChange}
+                        value={this.state.newActionRuleSmsPhoneNumberColumn}
+                        error={this.state.smsPhoneNumberColumnValidationError}
+                      >
+                        {sensitiveSampleColumnsMenuItems}
+                      </Select>
+                    </FormControl>
                   </>
                 )}
                 <TextField

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -77,9 +77,11 @@ class CollectionExerciseDetails extends Component {
   };
 
   getSensitiveSampleColumns = async () => {
-    const sensitiveSampleColumns = await getSensitiveSampleColumns(this.props.surveyId)
+    const sensitiveSampleColumns = await getSensitiveSampleColumns(
+      this.props.surveyId
+    );
     this.setState({ sensitiveSampleColumns: sensitiveSampleColumns });
-  }
+  };
 
   getCollectionExerciseName = async () => {
     const response = await fetch(
@@ -332,11 +334,12 @@ class CollectionExerciseDetails extends Component {
       </MenuItem>
     ));
 
-    const sensitiveSampleColumnsMenuItems = this.state.sensitiveSampleColumns.map((column) => (
-      <MenuItem key={column} value={column}>
-        {column}
-      </MenuItem>
-    ));
+    const sensitiveSampleColumnsMenuItems =
+      this.state.sensitiveSampleColumns.map((column) => (
+        <MenuItem key={column} value={column}>
+          {column}
+        </MenuItem>
+      ));
 
     let allowedActionRuleTypeMenuItems = [];
     if (this.state.authorisedActivities.includes("CREATE_PRINT_ACTION_RULE")) {

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -415,14 +415,6 @@ class LandingPage extends Component {
         if (!Array.isArray(parsedJson)) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
-        } else {
-          const validTemplateItems = ["__uac__", "__qid__"];
-          parsedJson.forEach((item) => {
-            if (!validTemplateItems.includes(item)) {
-              this.setState({ templateValidationError: true });
-              failedValidation = true;
-            }
-          });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -70,9 +70,7 @@ class PrintFulfilment extends Component {
   refreshDataFromBackend = async () => {
     const fulfilmentPrintTemplates = await getFulfilmentPrintTemplates(
       this.props.surveyId
-    ).then((fulfilmentTemplates) => {
-      return fulfilmentTemplates;
-    });
+    );
 
     this.setState({
       allowableFulfilmentPrintTemplates: fulfilmentPrintTemplates,

--- a/ui/src/SensitiveData.js
+++ b/ui/src/SensitiveData.js
@@ -10,7 +10,7 @@ import {
   Select,
   TextField,
 } from "@material-ui/core";
-import { getSensitiveSampleColumns } from './Utils'
+import { getSensitiveSampleColumns } from "./Utils";
 
 class SensitiveData extends Component {
   state = {
@@ -23,14 +23,12 @@ class SensitiveData extends Component {
   };
 
   openDialog = () => {
-    getSensitiveSampleColumns(this.props.surveyId).then(
-      (sensitiveColumns) => {
-        this.setState({
-          allowableSensitiveDataColumns: sensitiveColumns,
-          showDialog: true,
-        });
-      }
-    );
+    getSensitiveSampleColumns(this.props.surveyId).then((sensitiveColumns) => {
+      this.setState({
+        allowableSensitiveDataColumns: sensitiveColumns,
+        showDialog: true,
+      });
+    });
   };
 
   closeDialog = () => {

--- a/ui/src/SensitiveData.js
+++ b/ui/src/SensitiveData.js
@@ -10,6 +10,7 @@ import {
   Select,
   TextField,
 } from "@material-ui/core";
+import { getSensitiveSampleColumns } from './Utils'
 
 class SensitiveData extends Component {
   state = {
@@ -22,7 +23,7 @@ class SensitiveData extends Component {
   };
 
   openDialog = () => {
-    this.getSensitiveSampleColumns(this.props.surveyId).then(
+    getSensitiveSampleColumns(this.props.surveyId).then(
       (sensitiveColumns) => {
         this.setState({
           allowableSensitiveDataColumns: sensitiveColumns,
@@ -40,20 +41,6 @@ class SensitiveData extends Component {
       showDialog: false,
       validationError: false,
     });
-  };
-
-  getSensitiveSampleColumns = async () => {
-    const response = await fetch(`/api/surveys/${this.props.surveyId}`);
-    if (!response.ok) {
-      return;
-    }
-
-    const surveyJson = await response.json();
-    const sensitiveColumns = surveyJson.sampleValidationRules
-      .filter((rule) => rule.sensitive)
-      .map((rule) => rule.columnName);
-
-    return sensitiveColumns;
   };
 
   onSensitiveDataColumnChange = (event) => {

--- a/ui/src/SmsFulfilment.js
+++ b/ui/src/SmsFulfilment.js
@@ -50,9 +50,7 @@ class SmsFulfilment extends Component {
   refreshDataFromBackend = async () => {
     const fulfilmentPrintTemplates = await getSmsFulfilmentTemplates(
       this.props.surveyId
-    ).then((smsTemplates) => {
-      return smsTemplates;
-    });
+    );
 
     this.setState({
       allowableSmsFulfilmentTemplates: fulfilmentPrintTemplates,

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -93,39 +93,23 @@ class SurveyDetails extends Component {
   refreshDataFromBackend = async () => {
     this.getCollectionExercises();
 
-    const allPrintFulfilmentTemplates = await getAllPrintTemplates().then(
-      (templates) => {
-        return templates;
-      }
-    );
-    const allSmsFulfilmentTemplates = await getAllSmsTemplates().then(
-      (templates) => {
-        return templates;
-      }
-    );
+    const allPrintFulfilmentTemplates = await getAllPrintTemplates();
+    const allSmsFulfilmentTemplates = await getAllSmsTemplates();
 
     const actionRulePrintTemplates = await getActionRulePrintTemplates(
       this.props.surveyId
-    ).then((actionRuleTemplates) => {
-      return actionRuleTemplates;
-    });
+    );
 
     const actionRuleSmsTemplates = await getActionRuleSmsTemplates(
       this.props.surveyId
-    ).then((actionRuleTemplates) => {
-      return actionRuleTemplates;
-    });
+    );
 
     const fulfilmentPrintTemplates = await getFulfilmentPrintTemplates(
       this.props.surveyId
-    ).then((fulfilmentTemplates) => {
-      return fulfilmentTemplates;
-    });
+    );
     const smsFulfilmentTemplates = await getSmsFulfilmentTemplates(
       this.props.surveyId
-    ).then((smsTemplates) => {
-      return smsTemplates;
-    });
+    );
 
     let allowableActionRulePrintTemplates = [];
     let allowableActionRuleSmsTemplates = [];

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -21,6 +21,7 @@ import TableRow from "@material-ui/core/TableRow";
 import { uuidv4 } from "./common";
 import {
   getActionRulePrintTemplates,
+  getActionRuleSmsTemplates,
   getAllPrintTemplates,
   getFulfilmentPrintTemplates,
   getSmsFulfilmentTemplates,
@@ -37,18 +38,23 @@ class SurveyDetails extends Component {
     validationError: false,
     newCollectionExerciseName: "",
     allowActionRulePrintTemplateDialogDisplayed: false,
+    allowActionRuleSmsTemplateDialogDisplayed: false,
     allowFulfilmentPrintTemplateDialogDisplayed: false,
     allowSmsFulfilmentTemplateDialogDisplayed: false,
     actionRulePrintTemplates: [],
+    actionRuleSmsTemplates: [],
     fulfilmentPrintTemplates: [],
     smsFulfilmentTemplates: [],
     allowableActionRulePrintTemplates: [],
+    allowableActionRuleSmsTemplates: [],
     allowableFulfilmentPrintTemplates: [],
     allowableSmsFulfilmentTemplates: [],
     printTemplateToAllow: "",
     smsTemplateToAllow: "",
     printTemplateValidationError: false,
+    smsTemplateValidationError: false,
     allowPrintTemplateError: "",
+    allowSmsTemplateError: "",
   };
 
   componentDidMount() {
@@ -104,6 +110,12 @@ class SurveyDetails extends Component {
       return actionRuleTemplates;
     });
 
+    const actionRuleSmsTemplates = await getActionRuleSmsTemplates(
+      this.props.surveyId
+    ).then((actionRuleTemplates) => {
+      return actionRuleTemplates;
+    });
+
     const fulfilmentPrintTemplates = await getFulfilmentPrintTemplates(
       this.props.surveyId
     ).then((fulfilmentTemplates) => {
@@ -116,6 +128,7 @@ class SurveyDetails extends Component {
     });
 
     let allowableActionRulePrintTemplates = [];
+    let allowableActionRuleSmsTemplates = [];
     let allowableFulfilmentPrintTemplates = [];
     let allowableSmsFulfilmentTemplates = [];
     allPrintFulfilmentTemplates.forEach((packCode) => {
@@ -128,6 +141,10 @@ class SurveyDetails extends Component {
       }
     });
     allSmsFulfilmentTemplates.forEach((packCode) => {
+      if (!actionRuleSmsTemplates.includes(packCode)) {
+        allowableActionRuleSmsTemplates.push(packCode);
+      }
+
       if (!smsFulfilmentTemplates.includes(packCode)) {
         allowableSmsFulfilmentTemplates.push(packCode);
       }
@@ -135,9 +152,11 @@ class SurveyDetails extends Component {
 
     this.setState({
       actionRulePrintTemplates: actionRulePrintTemplates,
+      actionRuleSmsTemplates: actionRuleSmsTemplates,
       fulfilmentPrintTemplates: fulfilmentPrintTemplates,
       smsFulfilmentTemplates: smsFulfilmentTemplates,
       allowableActionRulePrintTemplates: allowableActionRulePrintTemplates,
+      allowableActionRuleSmsTemplates: allowableActionRuleSmsTemplates,
       allowableFulfilmentPrintTemplates: allowableFulfilmentPrintTemplates,
       allowableSmsFulfilmentTemplates: allowableSmsFulfilmentTemplates,
     });
@@ -206,6 +225,15 @@ class SurveyDetails extends Component {
     });
   };
 
+  openActionRuleSmsTemplateDialog = () => {
+    this.setState({
+      allowActionRuleSmsTemplateDialogDisplayed: true,
+      smsTemplateToAllow: "",
+      smsTemplateValidationError: false,
+      allowSmsTemplateError: "",
+    });
+  };
+
   openFulfilmentPrintTemplateDialog = () => {
     this.setState({
       allowFulfilmentPrintTemplateDialogDisplayed: true,
@@ -214,6 +242,7 @@ class SurveyDetails extends Component {
       allowPrintTemplateError: "",
     });
   };
+
   openSmsFulfilmentTemplateDialog = () => {
     this.setState({
       allowSmsFulfilmentTemplateDialogDisplayed: true,
@@ -222,6 +251,7 @@ class SurveyDetails extends Component {
       allowPrintTemplateError: "",
     });
   };
+
   onAllowActionRulePrintTemplate = async () => {
     if (!this.state.printTemplateToAllow) {
       this.setState({
@@ -248,6 +278,36 @@ class SurveyDetails extends Component {
       const errorMessage = await response.text();
       this.setState({
         allowPrintTemplateError: errorMessage,
+      });
+    }
+  };
+
+  onAllowActionRuleSmsTemplate = async () => {
+    if (!this.state.smsTemplateToAllow) {
+      this.setState({
+        smsTemplateValidationError: true,
+      });
+
+      return;
+    }
+
+    const newAllowSmsTemplate = {
+      surveyId: this.props.surveyId,
+      packCode: this.state.smsTemplateToAllow,
+    };
+
+    const response = await fetch("/api/actionRuleSurveySmsTemplates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newAllowSmsTemplate),
+    });
+
+    if (response.ok) {
+      this.setState({ allowActionRuleSmsTemplateDialogDisplayed: false });
+    } else {
+      const errorMessage = await response.text();
+      this.setState({
+        allowSmsTemplateError: errorMessage,
       });
     }
   };
@@ -281,6 +341,7 @@ class SurveyDetails extends Component {
       });
     }
   };
+
   onAllowSmsFulfilmentTemplate = async () => {
     if (!this.state.smsTemplateToAllow) {
       this.setState({
@@ -316,9 +377,14 @@ class SurveyDetails extends Component {
     this.setState({ allowActionRulePrintTemplateDialogDisplayed: false });
   };
 
+  closeAllowActionRuleSmsTemplateDialog = () => {
+    this.setState({ allowActionRuleSmsTemplateDialogDisplayed: false });
+  };
+
   closeAllowFulfilmentPrintTemplateDialog = () => {
     this.setState({ allowFulfilmentPrintTemplateDialogDisplayed: false });
   };
+
   closeAllowSmsFulfilmentTemplateDialog = () => {
     this.setState({ allowSmsFulfilmentTemplateDialogDisplayed: false });
   };
@@ -326,6 +392,7 @@ class SurveyDetails extends Component {
   onPrintTemplateChange = (event) => {
     this.setState({ printTemplateToAllow: event.target.value });
   };
+
   onSmsTemplateChange = (event) => {
     this.setState({ smsTemplateToAllow: event.target.value });
   };
@@ -358,6 +425,15 @@ class SurveyDetails extends Component {
         </TableRow>
       ));
 
+    const actionRuleSmsTemplateTableRows =
+      this.state.actionRuleSmsTemplates.map((smsTemplate) => (
+        <TableRow key={smsTemplate}>
+          <TableCell component="th" scope="row">
+            {smsTemplate}
+          </TableCell>
+        </TableRow>
+      ));
+
     const fulfilmentPrintTemplateTableRows =
       this.state.fulfilmentPrintTemplates.map((printTemplate) => (
         <TableRow key={printTemplate}>
@@ -366,6 +442,7 @@ class SurveyDetails extends Component {
           </TableCell>
         </TableRow>
       ));
+
     const smsFulfilmentTemplateTableRows =
       this.state.smsFulfilmentTemplates.map((printTemplate) => (
         <TableRow key={printTemplate}>
@@ -374,8 +451,16 @@ class SurveyDetails extends Component {
           </TableCell>
         </TableRow>
       ));
+
     const actionRulePrintTemplateMenuItems =
       this.state.allowableActionRulePrintTemplates.map((packCode) => (
+        <MenuItem key={packCode} value={packCode}>
+          {packCode}
+        </MenuItem>
+      ));
+
+    const actionRuleSmsTemplateMenuItems =
+      this.state.allowableActionRuleSmsTemplates.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>
@@ -387,6 +472,7 @@ class SurveyDetails extends Component {
           {packCode}
         </MenuItem>
       ));
+
     const smsFulfilmentTemplateMenuItems =
       this.state.allowableSmsFulfilmentTemplates.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
@@ -450,6 +536,31 @@ class SurveyDetails extends Component {
                 </TableRow>
               </TableHead>
               <TableBody>{actionRulePrintTemplateTableRows}</TableBody>
+            </Table>
+          </TableContainer>
+        )}
+        {this.state.authorisedActivities.includes(
+          "ALLOW_SMS_TEMPLATE_ON_ACTION_RULE"
+        ) && (
+          <Button
+            variant="contained"
+            onClick={this.openActionRuleSmsTemplateDialog}
+            style={{ marginTop: 20 }}
+          >
+            Allow SMS Template on Action Rule
+          </Button>
+        )}
+        {this.state.authorisedActivities.includes(
+          "LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES"
+        ) && (
+          <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Pack Code</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>{actionRuleSmsTemplateTableRows}</TableBody>
             </Table>
           </TableContainer>
         )}
@@ -568,6 +679,47 @@ class SurveyDetails extends Component {
                 </Button>
                 <Button
                   onClick={this.closeAllowActionRulePrintTemplateDialog}
+                  variant="contained"
+                  style={{ margin: 10 }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={this.state.allowActionRuleSmsTemplateDialogDisplayed}>
+          <DialogContent style={{ padding: 30 }}>
+            <div>
+              <div>
+                <FormControl required fullWidth={true}>
+                  <InputLabel>SMS Template</InputLabel>
+                  <Select
+                    onChange={this.onSmsTemplateChange}
+                    value={this.state.smsTemplateToAllow}
+                    error={this.state.smsTemplateValidationError}
+                  >
+                    {actionRuleSmsTemplateMenuItems}
+                  </Select>
+                </FormControl>
+              </div>
+              {this.state.allowSmsTemplateError && (
+                <div>
+                  <p style={{ color: "red" }}>
+                    {this.state.allowSmsTemplateError}
+                  </p>
+                </div>
+              )}
+              <div style={{ marginTop: 10 }}>
+                <Button
+                  onClick={this.onAllowActionRuleSmsTemplate}
+                  variant="contained"
+                  style={{ margin: 10 }}
+                >
+                  Allow
+                </Button>
+                <Button
+                  onClick={this.closeAllowActionRuleSmsTemplateDialog}
                   variant="contained"
                   style={{ margin: 10 }}
                 >

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -103,3 +103,25 @@ export const getActionRulePrintTemplates = async (surveyId) => {
 
   return templates;
 };
+
+export const getActionRuleSmsTemplates = async (surveyId) => {
+  const response = await fetch(
+    `/api/surveys/${surveyId}/actionRuleSmsTemplates`
+  );
+  const smsTemplatesJson = await response.json();
+  const smsTemplates = smsTemplatesJson._embedded.actionRuleSurveySmsTemplates;
+
+  let templates = [];
+
+  for (let i = 0; i < smsTemplates.length; i++) {
+    const print_template_url = new URL(smsTemplates[i]._links.smsTemplate.href);
+
+    const smsTemplateResponse = await fetch(print_template_url.pathname);
+    const smsTemplateJson = await smsTemplateResponse.json();
+    const packCode = smsTemplateJson._links.self.href.split("/").pop();
+
+    templates.push(packCode);
+  }
+
+  return templates;
+};

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -125,3 +125,17 @@ export const getActionRuleSmsTemplates = async (surveyId) => {
 
   return templates;
 };
+
+export const getSensitiveSampleColumns = async (surveyId) => {
+  const response = await fetch(`/api/surveys/${surveyId}`);
+  if (!response.ok) {
+    return;
+  }
+
+  const surveyJson = await response.json();
+  const sensitiveColumns = surveyJson.sampleValidationRules
+    .filter((rule) => rule.sensitive)
+    .map((rule) => rule.columnName);
+
+  return sensitiveColumns;
+};


### PR DESCRIPTION
# Motivation and Context
To run SMS action rules we need the Case Processor to send SMSs driven by action rules.

# What has changed
Allowed action rules to send SMSs.

# How to test?
Check out and build the linking DDL branch to build the required common entities snapshot.
Check out and build the other linked service branches
Check out and run the linked docker dev branch
Check out and run the linked ATs branch

# Links
https://trello.com/c/LvFNl7N6/2851-sis2-enable-action-rules-to-send-sms-messages-21

# Screenshots (if appropriate):
<img width="1037" alt="Screenshot 2021-09-22 at 18 02 38" src="https://user-images.githubusercontent.com/41681172/134391129-a0164372-6055-4856-9abb-c01fa981a952.png">
<img width="1037" alt="Screenshot 2021-09-22 at 18 02 58" src="https://user-images.githubusercontent.com/41681172/134391138-93e67172-dc5a-43c5-bb27-1867088f1587.png">
<img width="1038" alt="Screenshot 2021-09-22 at 18 03 09" src="https://user-images.githubusercontent.com/41681172/134391143-b00482e3-765c-4bcb-b9be-82d33baea836.png">
<img width="1032" alt="Screenshot 2021-09-22 at 18 17 30" src="https://user-images.githubusercontent.com/41681172/134391148-194bd5f6-a8ab-449f-8613-c33539f35008.png">
