### PR TITLE
Add regex rule for phone numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.3.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/test/resources/example-validator-config.json
+++ b/src/test/resources/example-validator-config.json
@@ -48,6 +48,11 @@
   {
     "columnName": "PHONE_NUMBER",
     "sensitive": true,
-    "rules": []
+    "rules": [
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "^07[0-9]{9}$"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Motivation and Context
We are planning on using a CSV sample load as a tactical solution for SIS2 wave one. This sample file will contain phone numbers, which we will need a way of validating.

# What has changed
Added regex validation.

# How to test?
Set up a survey with a column validation rule like this...

```json
  {
    "columnName": "PHONE_NUMBER",
    "sensitive": true,
    "rules": [
      {
        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
        "expression": "^07[0-9]{9}$"
      }
    ]
  }
```

Then, try loading a sample with dodgy phone numbers.

# Links
Trello: https://trello.com/c/PW2rRdlL