### PR TITLE
Replace Spring CRUD APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jobs:
 
       before_install:
         - make format-check-mvn
+        - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
         - echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > ~/google-service-account-key.json
         - export GOOGLE_APPLICATION_CREDENTIALS=~/google-service-account-key.json
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.3.1-SNAPSHOT</version>
+      <version>2.3.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-rest</artifactId>
-
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/client/ExceptionManagerClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/client/ExceptionManagerClient.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.SkipMessageRequest;
+import uk.gov.ons.ssdc.supporttool.model.dto.rest.SkipMessageRequest;
 
 @Component
 public class ExceptionManagerClient {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
@@ -2,48 +2,83 @@ package uk.gov.ons.ssdc.supporttool.endpoint;
 
 import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveyPrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.ActionRuleSurveyPrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
-@Controller
+@RestController
 @RequestMapping(value = "/api/actionRuleSurveyPrintTemplates")
 public class ActionRuleSurveyPrintTemplateEndpoint {
   private final ActionRuleSurveyPrintTemplateRepository actionRuleSurveyPrintTemplateRepository;
   private final SurveyRepository surveyRepository;
   private final PrintTemplateRepository printTemplateRepository;
+  private final UserIdentity userIdentity;
 
   public ActionRuleSurveyPrintTemplateEndpoint(
       ActionRuleSurveyPrintTemplateRepository actionRuleSurveyPrintTemplateRepository,
       SurveyRepository surveyRepository,
-      PrintTemplateRepository printTemplateRepository) {
+      PrintTemplateRepository printTemplateRepository,
+      UserIdentity userIdentity) {
     this.actionRuleSurveyPrintTemplateRepository = actionRuleSurveyPrintTemplateRepository;
     this.surveyRepository = surveyRepository;
     this.printTemplateRepository = printTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
+  public List<String> getAllowedPackCodesBySurvey(
+      @RequestParam(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail,
+        survey,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES);
+
+    return actionRuleSurveyPrintTemplateRepository.findBySurvey(survey).stream()
+        .map(arspt -> arspt.getPrintTemplate().getPackCode())
+        .collect(Collectors.toList());
   }
 
   @PostMapping
   public ResponseEntity<String> createActionRuleSurveyPrintTemplate(
-      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
         surveyRepository
             .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.ALLOW_PRINT_TEMPLATE_ON_ACTION_RULE);
 
     PrintTemplate printTemplate =
         printTemplateRepository

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
@@ -2,48 +2,83 @@ package uk.gov.ons.ssdc.supporttool.endpoint;
 
 import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveySmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.ActionRuleSurveySmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
-@Controller
+@RestController
 @RequestMapping(value = "/api/actionRuleSurveySmsTemplates")
 public class ActionRuleSurveySmsTemplateEndpoint {
   private final ActionRuleSurveySmsTemplateRepository actionRuleSurveySmsTemplateRepository;
   private final SurveyRepository surveyRepository;
   private final SmsTemplateRepository smsTemplateRepository;
+  private final UserIdentity userIdentity;
 
   public ActionRuleSurveySmsTemplateEndpoint(
       ActionRuleSurveySmsTemplateRepository actionRuleSurveySmsTemplateRepository,
       SurveyRepository surveyRepository,
-      SmsTemplateRepository smsTemplateRepository) {
+      SmsTemplateRepository smsTemplateRepository,
+      UserIdentity userIdentity) {
     this.actionRuleSurveySmsTemplateRepository = actionRuleSurveySmsTemplateRepository;
     this.surveyRepository = surveyRepository;
     this.smsTemplateRepository = smsTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
+  public List<String> getAllowedPackCodesBySurvey(
+      @RequestParam(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail,
+        survey,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES);
+
+    return actionRuleSurveySmsTemplateRepository.findBySurvey(survey).stream()
+        .map(arsst -> arsst.getSmsTemplate().getPackCode())
+        .collect(Collectors.toList());
   }
 
   @PostMapping
   public ResponseEntity<String> createActionRuleSurveySmsTemplate(
-      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
         surveyRepository
             .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.ALLOW_SMS_TEMPLATE_ON_ACTION_RULE);
 
     SmsTemplate smsTemplate =
         smsTemplateRepository

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
@@ -21,10 +21,10 @@ import uk.gov.ons.ssdc.supporttool.model.repository.UserRepository;
 
 @RestController
 @RequestMapping(value = "/api/auth")
-public class Authorisation {
+public class AuthorisationEndpoint {
   private final UserRepository userRepository;
 
-  public Authorisation(UserRepository userRepository) {
+  public AuthorisationEndpoint(UserRepository userRepository) {
     this.userRepository = userRepository;
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisedActivityTypesEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisedActivityTypesEndpoint.java
@@ -8,7 +8,7 @@ import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 
 @RestController
 @RequestMapping(value = "/api/authorisedActivityTypes")
-public class AuthorisedActivityTypes {
+public class AuthorisedActivityTypesEndpoint {
   private static final Set<UserGroupAuthorisedActivityType> AUTHORISED_ACTIVITY_TYPES =
       Set.of(UserGroupAuthorisedActivityType.values());
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
@@ -5,17 +5,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.ons.ssdc.common.model.entity.Case;
+import uk.gov.ons.ssdc.common.model.entity.Event;
+import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
 import uk.gov.ons.ssdc.supporttool.client.NotifyServiceClient;
@@ -24,14 +26,17 @@ import uk.gov.ons.ssdc.supporttool.model.dto.rest.RequestDTO;
 import uk.gov.ons.ssdc.supporttool.model.dto.rest.RequestHeaderDTO;
 import uk.gov.ons.ssdc.supporttool.model.dto.rest.RequestPayloadDTO;
 import uk.gov.ons.ssdc.supporttool.model.dto.rest.SmsFulfilment;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.CaseDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.EventDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.InvalidCase;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintFulfilment;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.Refusal;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsFulfilmentAction;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UacQidLinkDto;
 import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 import uk.gov.ons.ssdc.supporttool.service.CaseService;
 
-@Controller
+@RestController
 @RequestMapping(value = "/api/cases")
 public class CaseEndpoint {
 
@@ -39,12 +44,72 @@ public class CaseEndpoint {
   private final CaseService caseService;
   private final UserIdentity userIdentity;
 
-  @Autowired
   public CaseEndpoint(
       NotifyServiceClient notifyServiceClient, UserIdentity userIdentity, CaseService caseService) {
     this.notifyServiceClient = notifyServiceClient;
     this.userIdentity = userIdentity;
     this.caseService = caseService;
+  }
+
+  @GetMapping("/{caseId}")
+  public CaseDto getCase(
+      @PathVariable(value = "caseId") UUID caseId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Case caze = caseService.getCaseByCaseId(caseId);
+
+    userIdentity.checkUserPermission(
+        userEmail,
+        caze.getCollectionExercise().getSurvey(),
+        UserGroupAuthorisedActivityType.VIEW_CASE_DETAILS);
+
+    CaseDto caseDto = new CaseDto();
+    caseDto.setCollectionExerciseName(caze.getCollectionExercise().getName());
+    caseDto.setCaseRef(caze.getCaseRef());
+    caseDto.setRefusalReceived(caze.getRefusalReceived());
+    caseDto.setInvalid(caze.isInvalid());
+    caseDto.setReceiptReceived(caze.isReceiptReceived());
+    caseDto.setEqLaunched(caze.isEqLaunched());
+    caseDto.setCreatedAt(caze.getCreatedAt());
+    caseDto.setLastUpdatedAt(caze.getLastUpdatedAt());
+
+    List<EventDto> events = new LinkedList<>();
+    for (Event event : caze.getEvents()) {
+      EventDto eventDto = mapEventDto(event);
+      events.add(eventDto);
+    }
+
+    List<UacQidLinkDto> uacQidLinks = new LinkedList<>();
+    for (UacQidLink uacQidLink : caze.getUacQidLinks()) {
+      UacQidLinkDto uacQidLinkDto = new UacQidLinkDto();
+      uacQidLinkDto.setQid(uacQidLink.getQid());
+      uacQidLinkDto.setActive(uacQidLink.isActive());
+      uacQidLinkDto.setCreatedAt(uacQidLink.getCreatedAt());
+      uacQidLinkDto.setLastUpdatedAt(uacQidLink.getLastUpdatedAt());
+      uacQidLinks.add(uacQidLinkDto);
+
+      for (Event event : uacQidLink.getEvents()) {
+        EventDto eventDto = mapEventDto(event);
+        events.add(eventDto);
+      }
+    }
+
+    caseDto.setUacQidLinks(uacQidLinks);
+    caseDto.setEvents(events);
+
+    return caseDto;
+  }
+
+  private EventDto mapEventDto(Event event) {
+    EventDto eventDto = new EventDto();
+    eventDto.setDescription(event.getDescription());
+    eventDto.setDateTime(event.getDateTime());
+    eventDto.setType(event.getType());
+    eventDto.setChannel(event.getChannel());
+    eventDto.setSource(event.getSource());
+    eventDto.setMessageId(event.getMessageId());
+    eventDto.setPayload(event.getPayload());
+    eventDto.setCorrelationId(event.getCorrelationId());
+    return eventDto;
   }
 
   @PostMapping("{caseId}/action/updateSensitiveField")

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
@@ -1,12 +1,16 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
@@ -31,6 +35,32 @@ public class CollectionExerciseEndpoint {
     this.collectionExerciseRepository = collectionExerciseRepository;
     this.surveyRepository = surveyRepository;
     this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  public List<CollectionExerciseDto> findCollexsBySurvey(
+      @RequestParam(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.LIST_COLLECTION_EXERCISES);
+
+    return collectionExerciseRepository.findBySurvey(survey).stream()
+        .map(
+            collex -> {
+              CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+              collectionExerciseDto.setId(collex.getId());
+              collectionExerciseDto.setSurveyId(surveyId);
+              collectionExerciseDto.setName(collex.getName());
+              return collectionExerciseDto;
+            })
+        .collect(Collectors.toList());
   }
 
   @PostMapping

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManager.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.client.ExceptionManagerClient;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.SkipMessageRequest;
+import uk.gov.ons.ssdc.supporttool.model.dto.rest.SkipMessageRequest;
 import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
 @Controller

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManagerEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExceptionManagerEndpoint.java
@@ -14,11 +14,11 @@ import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
 @Controller
 @RequestMapping(value = "/api/exceptionManager")
-public class ExceptionManager {
+public class ExceptionManagerEndpoint {
   private final ExceptionManagerClient exceptionManagerClient;
   private final UserIdentity userIdentity;
 
-  public ExceptionManager(
+  public ExceptionManagerEndpoint(
       ExceptionManagerClient exceptionManagerClient, UserIdentity userIdentity) {
     this.exceptionManagerClient = exceptionManagerClient;
     this.userIdentity = userIdentity;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentNextTriggerEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentNextTriggerEndpoint.java
@@ -1,0 +1,80 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.FulfilmentNextTrigger;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentNextTriggerRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/fulfilmentNextTriggers")
+public class FulfilmentNextTriggerEndpoint {
+  private final FulfilmentNextTriggerRepository fulfilmentNextTriggerRepository;
+  private final UserIdentity userIdentity;
+
+  public FulfilmentNextTriggerEndpoint(
+      FulfilmentNextTriggerRepository fulfilmentNextTriggerRepository, UserIdentity userIdentity) {
+    this.fulfilmentNextTriggerRepository = fulfilmentNextTriggerRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  public OffsetDateTime getTriggerDateTime(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CONFIGURE_FULFILMENT_TRIGGER);
+
+    List<FulfilmentNextTrigger> fulfilmentNextTriggers = fulfilmentNextTriggerRepository.findAll();
+    if (fulfilmentNextTriggers.size() > 1) {
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Multiple triggers not currently supported");
+    }
+
+    if (fulfilmentNextTriggers.size() == 0) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
+
+    return fulfilmentNextTriggers.get(0).getTriggerDateTime();
+  }
+
+  @PostMapping
+  public void setTriggerDateTime(
+      @RequestParam(value = "triggerDateTime") String triggerDateTime,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CONFIGURE_FULFILMENT_TRIGGER);
+
+    List<FulfilmentNextTrigger> fulfilmentNextTriggers = fulfilmentNextTriggerRepository.findAll();
+
+    if (fulfilmentNextTriggers.size() > 1) {
+      throw new HttpClientErrorException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Multiple triggers not currently supported");
+    }
+
+    FulfilmentNextTrigger fulfilmentNextTrigger;
+
+    if (fulfilmentNextTriggers.size() == 0) {
+      fulfilmentNextTrigger = new FulfilmentNextTrigger();
+      fulfilmentNextTrigger.setId(UUID.randomUUID());
+    } else {
+      fulfilmentNextTrigger = fulfilmentNextTriggers.get(0);
+    }
+
+    OffsetDateTime triggerDateTimeParsed =
+        OffsetDateTime.parse(triggerDateTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    fulfilmentNextTrigger.setTriggerDateTime(triggerDateTimeParsed);
+    fulfilmentNextTriggerRepository.saveAndFlush(fulfilmentNextTrigger);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyPrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyPrintTemplateEndpoint.java
@@ -2,48 +2,83 @@ package uk.gov.ons.ssdc.supporttool.endpoint;
 
 import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyPrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveyPrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
-@Controller
+@RestController
 @RequestMapping(value = "/api/fulfilmentSurveyPrintTemplates")
 public class FulfilmentSurveyPrintTemplateEndpoint {
   private final FulfilmentSurveyPrintTemplateRepository fulfilmentSurveyPrintTemplateRepository;
   private final SurveyRepository surveyRepository;
   private final PrintTemplateRepository printTemplateRepository;
+  private final UserIdentity userIdentity;
 
   public FulfilmentSurveyPrintTemplateEndpoint(
       FulfilmentSurveyPrintTemplateRepository fulfilmentSurveyPrintTemplateRepository,
       SurveyRepository surveyRepository,
-      PrintTemplateRepository printTemplateRepository) {
+      PrintTemplateRepository printTemplateRepository,
+      UserIdentity userIdentity) {
     this.fulfilmentSurveyPrintTemplateRepository = fulfilmentSurveyPrintTemplateRepository;
     this.surveyRepository = surveyRepository;
     this.printTemplateRepository = printTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
+  public List<String> getAllowedPackCodesBySurvey(
+      @RequestParam(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail,
+        survey,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS);
+
+    return fulfilmentSurveyPrintTemplateRepository.findBySurvey(survey).stream()
+        .map(fspt -> fspt.getPrintTemplate().getPackCode())
+        .collect(Collectors.toList());
   }
 
   @PostMapping
   public ResponseEntity<String> createFulfilmentSurveyPrintTemplate(
-      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
         surveyRepository
             .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.ALLOW_PRINT_TEMPLATE_ON_FULFILMENT);
 
     PrintTemplate printTemplate =
         printTemplateRepository

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
@@ -2,23 +2,30 @@ package uk.gov.ons.ssdc.supporttool.endpoint;
 
 import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveySmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
-import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveySmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 
 @RestController
 @RequestMapping(value = "/api/fulfilmentSurveySmsTemplates")
@@ -26,24 +33,52 @@ public class FulfilmentSurveySmsTemplateEndpoint {
   private final FulfilmentSurveySmsTemplateRepository fulfilmentSurveySmsTemplateRepository;
   private final SurveyRepository surveyRepository;
   private final SmsTemplateRepository smsTemplateRepository;
+  private final UserIdentity userIdentity;
 
   public FulfilmentSurveySmsTemplateEndpoint(
       FulfilmentSurveySmsTemplateRepository fulfilmentSurveySmsTemplateRepository,
       SurveyRepository surveyRepository,
-      SmsTemplateRepository smsTemplateRepository) {
+      SmsTemplateRepository smsTemplateRepository,
+      UserIdentity userIdentity) {
     this.fulfilmentSurveySmsTemplateRepository = fulfilmentSurveySmsTemplateRepository;
     this.surveyRepository = surveyRepository;
     this.smsTemplateRepository = smsTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
+  public List<String> getAllowedPackCodesBySurvey(
+      @RequestParam(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail,
+        survey,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS);
+
+    return fulfilmentSurveySmsTemplateRepository.findBySurvey(survey).stream()
+        .map(fsst -> fsst.getSmsTemplate().getPackCode())
+        .collect(Collectors.toList());
   }
 
   @PostMapping
   public ResponseEntity<String> createFulfilmentSurveySmsTemplate(
-      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
         surveyRepository
             .findById(allowTemplateOnSurvey.getSurveyId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.ALLOW_SMS_TEMPLATE_ON_FULFILMENT);
 
     SmsTemplate smsTemplate =
         smsTemplateRepository

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
@@ -1,0 +1,70 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import static uk.gov.ons.ssdc.supporttool.utility.AllowTemplateOnSurveyValidator.validate;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.supporttool.model.dto.messaging.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveySmsTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+
+@RestController
+@RequestMapping(value = "/api/fulfilmentSurveySmsTemplates")
+public class FulfilmentSurveySmsTemplateEndpoint {
+  private final FulfilmentSurveySmsTemplateRepository fulfilmentSurveySmsTemplateRepository;
+  private final SurveyRepository surveyRepository;
+  private final SmsTemplateRepository smsTemplateRepository;
+
+  public FulfilmentSurveySmsTemplateEndpoint(
+      FulfilmentSurveySmsTemplateRepository fulfilmentSurveySmsTemplateRepository,
+      SurveyRepository surveyRepository,
+      SmsTemplateRepository smsTemplateRepository) {
+    this.fulfilmentSurveySmsTemplateRepository = fulfilmentSurveySmsTemplateRepository;
+    this.surveyRepository = surveyRepository;
+    this.smsTemplateRepository = smsTemplateRepository;
+  }
+
+  @PostMapping
+  public ResponseEntity<String> createFulfilmentSurveySmsTemplate(
+      @RequestBody AllowTemplateOnSurvey allowTemplateOnSurvey) {
+    Survey survey =
+        surveyRepository
+            .findById(allowTemplateOnSurvey.getSurveyId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    SmsTemplate smsTemplate =
+        smsTemplateRepository
+            .findById(allowTemplateOnSurvey.getPackCode())
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "Print template not found"));
+
+    Optional<String> errorOpt = validate(survey, Set.of(smsTemplate.getTemplate()));
+    if (errorOpt.isPresent()) {
+      return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
+    }
+
+    FulfilmentSurveySmsTemplate fulfilmentSurveySmsTemplate = new FulfilmentSurveySmsTemplate();
+    fulfilmentSurveySmsTemplate.setId(UUID.randomUUID());
+    fulfilmentSurveySmsTemplate.setSurvey(survey);
+    fulfilmentSurveySmsTemplate.setSmsTemplate(smsTemplate);
+
+    fulfilmentSurveySmsTemplateRepository.save(fulfilmentSurveySmsTemplate);
+
+    return new ResponseEntity<>("OK", HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintSuppliersEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintSuppliersEndpoint.java
@@ -19,7 +19,7 @@ import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
 
 @RestController
 @RequestMapping(value = "/api/printsuppliers")
-public class PrintSuppliers {
+public class PrintSuppliersEndpoint {
 
   public static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
 
@@ -30,7 +30,7 @@ public class PrintSuppliers {
 
   private Set<String> printSuppliers = null;
 
-  public PrintSuppliers(UserIdentity userIdentity) {
+  public PrintSuppliersEndpoint(UserIdentity userIdentity) {
     this.userIdentity = userIdentity;
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintTemplateEndpoint.java
@@ -1,0 +1,65 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintTemplateDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/printTemplates")
+public class PrintTemplateEndpoint {
+  private final PrintTemplateRepository printTemplateRepository;
+  private final UserIdentity userIdentity;
+
+  public PrintTemplateEndpoint(
+      PrintTemplateRepository printTemplateRepository, UserIdentity userIdentity) {
+    this.printTemplateRepository = printTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  public List<PrintTemplateDto> getTemplates(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.LIST_PRINT_TEMPLATES);
+
+    return printTemplateRepository.findAll().stream()
+        .map(
+            printTemplate -> {
+              PrintTemplateDto printTemplateDto = new PrintTemplateDto();
+              printTemplateDto.setTemplate(printTemplate.getTemplate());
+              printTemplateDto.setPrintSupplier(printTemplate.getPrintSupplier());
+              printTemplateDto.setPackCode(printTemplate.getPackCode());
+              return printTemplateDto;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createTemplate(
+      @RequestBody PrintTemplateDto printTemplateDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE);
+
+    PrintTemplate printTemplate = new PrintTemplate();
+    printTemplate.setTemplate(printTemplateDto.getTemplate());
+    printTemplate.setPrintSupplier(printTemplateDto.getPrintSupplier()); // TODO: check it exists
+    printTemplate.setPackCode(printTemplateDto.getPackCode());
+
+    printTemplateRepository.saveAndFlush(printTemplate);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -10,12 +10,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
-import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsTemplateDto;
-import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -1,0 +1,68 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintTemplateDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsTemplateDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.PrintTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/smsTemplates")
+public class SmsTemplateEndpoint {
+  private final SmsTemplateRepository smsTemplateRepository;
+  private final UserIdentity userIdentity;
+
+  public SmsTemplateEndpoint(
+      SmsTemplateRepository smsTemplateRepository, UserIdentity userIdentity) {
+    this.smsTemplateRepository = smsTemplateRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  public List<SmsTemplateDto> getTemplates(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.LIST_SMS_TEMPLATES);
+
+    return smsTemplateRepository.findAll().stream()
+        .map(
+            smsTemplate -> {
+              SmsTemplateDto smsTemplateDto = new SmsTemplateDto();
+              smsTemplateDto.setTemplate(smsTemplate.getTemplate());
+              smsTemplateDto.setPackCode(smsTemplate.getPackCode());
+              smsTemplateDto.setNotifyTemplateId(smsTemplate.getNotifyTemplateId());
+              return smsTemplateDto;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createTemplate(
+      @RequestBody SmsTemplateDto smsTemplateDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE);
+
+    SmsTemplate smsTemplate = new SmsTemplate();
+    smsTemplate.setTemplate(smsTemplateDto.getTemplate());
+    smsTemplate.setPackCode(smsTemplateDto.getPackCode());
+    smsTemplate.setNotifyTemplateId(smsTemplateDto.getNotifyTemplateId());
+
+    smsTemplateRepository.saveAndFlush(smsTemplate);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyCasesEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyCasesEndpoint.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.CaseSearchResult;
@@ -149,7 +149,7 @@ public class SurveyCasesEndpoint {
   private void checkSurveySearchCasesPermission(String userEmail, UUID surveyId) {
     Optional<Survey> surveyOptional = surveyRepository.findById(surveyId);
     if (surveyOptional.isEmpty()) {
-      throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "Survey not found");
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Survey not found");
     }
     userIdentity.checkUserPermission(
         userEmail, surveyOptional.get(), UserGroupAuthorisedActivityType.SEARCH_CASES);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyEndpoint.java
@@ -65,7 +65,7 @@ public class SurveyEndpoint {
   }
 
   @PostMapping
-  public ResponseEntity<Void> createSurvey(
+  public ResponseEntity<UUID> createSurvey(
       @RequestBody SurveyDto surveyDto,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     userIdentity.checkGlobalUserPermission(
@@ -79,6 +79,6 @@ public class SurveyEndpoint {
     survey.setSampleWithHeaderRow(surveyDto.isSampleWithHeaderRow());
     surveyRepository.saveAndFlush(survey);
 
-    return new ResponseEntity<>(HttpStatus.CREATED);
+    return new ResponseEntity<>(survey.getId(), HttpStatus.CREATED);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyEndpoint.java
@@ -1,0 +1,84 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.SurveyDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/surveys")
+public class SurveyEndpoint {
+  private final SurveyRepository surveyRepository;
+  private final UserIdentity userIdentity;
+
+  public SurveyEndpoint(SurveyRepository surveyRepository, UserIdentity userIdentity) {
+    this.surveyRepository = surveyRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping
+  public List<SurveyDto> getSurveys(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.LIST_SURVEYS);
+
+    return surveyRepository.findAll().stream().map(this::mapToDto).collect(Collectors.toList());
+  }
+
+  private SurveyDto mapToDto(Survey survey) {
+    SurveyDto surveyDto = new SurveyDto();
+    surveyDto.setId(survey.getId());
+    surveyDto.setName(survey.getName());
+    surveyDto.setSampleSeparator(survey.getSampleSeparator());
+    surveyDto.setSampleValidationRules(survey.getSampleValidationRules());
+    surveyDto.setSampleWithHeaderRow(survey.isSampleWithHeaderRow());
+    return surveyDto;
+  }
+
+  @GetMapping("/{surveyId}")
+  public SurveyDto getSurvey(
+      @PathVariable(value = "surveyId") UUID surveyId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    Survey survey =
+        surveyRepository
+            .findById(surveyId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+
+    userIdentity.checkUserPermission(
+        userEmail, survey, UserGroupAuthorisedActivityType.VIEW_SURVEY);
+
+    return mapToDto(survey);
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createSurvey(
+      @RequestBody SurveyDto surveyDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(
+        userEmail, UserGroupAuthorisedActivityType.CREATE_SURVEY);
+
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName(surveyDto.getName());
+    survey.setSampleSeparator(surveyDto.getSampleSeparator());
+    survey.setSampleValidationRules(surveyDto.getSampleValidationRules());
+    survey.setSampleWithHeaderRow(surveyDto.isSampleWithHeaderRow());
+    surveyRepository.saveAndFlush(survey);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserEndpoint.java
@@ -1,0 +1,76 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.User;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/users")
+public class UserEndpoint {
+  private final UserRepository userRepository;
+  private final UserIdentity userIdentity;
+
+  public UserEndpoint(UserRepository userRepository, UserIdentity userIdentity) {
+    this.userRepository = userRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping("/{userId}")
+  public UserDto getUser(
+      @PathVariable(value = "userId") UUID userId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    return mapDto(user);
+  }
+
+  @GetMapping
+  public List<UserDto> getUsers(@Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    return userRepository.findAll().stream().map(this::mapDto).collect(Collectors.toList());
+  }
+
+  private UserDto mapDto(User user) {
+    UserDto userDto = new UserDto();
+    userDto.setId(user.getId());
+    userDto.setEmail(user.getEmail());
+    return userDto;
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createUser(
+      @RequestBody UserDto userDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    User user = new User();
+    user.setId(UUID.randomUUID());
+    user.setEmail(userDto.getEmail());
+
+    userRepository.saveAndFlush(user);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
@@ -1,0 +1,76 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/userGroups")
+public class UserGroupEndpoint {
+  private final UserGroupRepository userGroupRepository;
+  private final UserIdentity userIdentity;
+
+  public UserGroupEndpoint(UserGroupRepository userGroupRepository, UserIdentity userIdentity) {
+    this.userGroupRepository = userGroupRepository;
+    this.userIdentity = userIdentity;
+  }
+
+  @GetMapping("/{groupId}")
+  public UserGroupDto getUserGroup(
+      @PathVariable(value = "groupId") UUID groupId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    UserGroup group =
+        userGroupRepository
+            .findById(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    return mapDto(group);
+  }
+
+  @GetMapping
+  public List<UserGroupDto> getUserGroups(
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    return userGroupRepository.findAll().stream().map(this::mapDto).collect(Collectors.toList());
+  }
+
+  private UserGroupDto mapDto(UserGroup group) {
+    UserGroupDto userGroupDto = new UserGroupDto();
+    userGroupDto.setId(group.getId());
+    userGroupDto.setName(group.getName());
+    return userGroupDto;
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> createGroup(
+      @RequestBody UserGroupDto userGroupDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    UserGroup userGroup = new UserGroup();
+    userGroup.setId(UUID.randomUUID());
+    userGroup.setName(userGroupDto.getName());
+    userGroupRepository.saveAndFlush(userGroup);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
@@ -1,0 +1,108 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.User;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupMember;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupMemberDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupMemberRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/userGroupMembers")
+public class UserGroupMemberEndpoint {
+  private final UserGroupMemberRepository userGroupMemberRepository;
+  private final UserIdentity userIdentity;
+  private final UserRepository userRepository;
+  private final UserGroupRepository userGroupRepository;
+
+  public UserGroupMemberEndpoint(
+      UserGroupMemberRepository userGroupMemberRepository,
+      UserIdentity userIdentity,
+      UserRepository userRepository,
+      UserGroupRepository userGroupRepository) {
+    this.userGroupMemberRepository = userGroupMemberRepository;
+    this.userIdentity = userIdentity;
+    this.userRepository = userRepository;
+    this.userGroupRepository = userGroupRepository;
+  }
+
+  @GetMapping
+  public List<UserGroupMemberDto> findByUser(
+      @RequestParam(value = "userId") UUID userId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
+
+    return userGroupMemberRepository.findByUser(user).stream()
+        .map(
+            member -> {
+              UserGroupMemberDto userGroupMemberDto = new UserGroupMemberDto();
+              userGroupMemberDto.setId(member.getId());
+              userGroupMemberDto.setGroupId(member.getGroup().getId());
+              userGroupMemberDto.setUserId(userId);
+              userGroupMemberDto.setGroupName(member.getGroup().getName());
+              return userGroupMemberDto;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> addUserToGroup(
+      @RequestBody UserGroupMemberDto userGroupMemberDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    User user =
+        userRepository
+            .findById(userGroupMemberDto.getUserId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
+
+    UserGroup group =
+        userGroupRepository
+            .findById(userGroupMemberDto.getGroupId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    UserGroupMember userGroupMember = new UserGroupMember();
+    userGroupMember.setId(UUID.randomUUID());
+    userGroupMember.setUser(user);
+    userGroupMember.setGroup(group);
+
+    userGroupMemberRepository.saveAndFlush(userGroupMember);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{groupMemberId}")
+  public void removeUserFromGroup(
+      @PathVariable(value = "groupMemberId") UUID groupMemberId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    userGroupMemberRepository.deleteById(groupMemberId);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -1,0 +1,117 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupPermission;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupPermissionDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupPermissionRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/userGroupPermissions")
+public class UserGroupPermissionEndpoint {
+  private final UserGroupPermissionRepository userGroupPermissionRepository;
+  private final UserIdentity userIdentity;
+  private final UserGroupRepository userGroupRepository;
+  private final SurveyRepository surveyRepository;
+
+  public UserGroupPermissionEndpoint(
+      UserGroupPermissionRepository userGroupPermissionRepository,
+      UserIdentity userIdentity,
+      UserGroupRepository userGroupRepository,
+      SurveyRepository surveyRepository) {
+    this.userGroupPermissionRepository = userGroupPermissionRepository;
+    this.userIdentity = userIdentity;
+    this.userGroupRepository = userGroupRepository;
+    this.surveyRepository = surveyRepository;
+  }
+
+  @GetMapping
+  public List<UserGroupPermissionDto> findByGroup(
+      @RequestParam(value = "groupId") UUID groupId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    UserGroup group =
+        userGroupRepository
+            .findById(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    return userGroupPermissionRepository.findByGroup(group).stream()
+        .map(
+            permission -> {
+              UserGroupPermissionDto userGroupPermissionDto = new UserGroupPermissionDto();
+              userGroupPermissionDto.setGroupId(permission.getGroup().getId());
+              userGroupPermissionDto.setId(permission.getId());
+              userGroupPermissionDto.setAuthorisedActivity(permission.getAuthorisedActivity());
+
+              if (permission.getSurvey() != null) {
+                userGroupPermissionDto.setSurveyId(permission.getSurvey().getId());
+                userGroupPermissionDto.setSurveyName(permission.getSurvey().getName());
+              }
+
+              return userGroupPermissionDto;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> addPermissionToGroup(
+      @RequestBody UserGroupPermissionDto userGroupPermissionDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    UserGroup group =
+        userGroupRepository
+            .findById(userGroupPermissionDto.getGroupId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    Survey survey = null;
+    if (userGroupPermissionDto.getSurveyId() != null) {
+      survey =
+          surveyRepository
+              .findById(userGroupPermissionDto.getSurveyId())
+              .orElseThrow(
+                  () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
+    }
+
+    UserGroupPermission userGroupPermission = new UserGroupPermission();
+    userGroupPermission.setId(UUID.randomUUID());
+    userGroupPermission.setGroup(group);
+    userGroupPermission.setAuthorisedActivity(userGroupPermissionDto.getAuthorisedActivity());
+    userGroupPermission.setSurvey(survey);
+
+    userGroupPermissionRepository.saveAndFlush(userGroupPermission);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{groupPermissionId}")
+  public void revokePermissionFromGroup(
+      @PathVariable(value = "groupPermissionId") UUID groupPermissionId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    userGroupPermissionRepository.deleteById(groupPermissionId);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/WhoAmIEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/WhoAmIEndpoint.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/api/whoami")
-public class WhoAmI {
+public class WhoAmIEndpoint {
   @GetMapping
   public Map<String, String> getWhoIAm(
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/SkipMessageRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/SkipMessageRequest.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
+package uk.gov.ons.ssdc.supporttool.model.dto.rest;
 
 import lombok.Data;
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -6,7 +6,7 @@ import lombok.Data;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
 
 @Data
-public class ActionRuleDTO {
+public class ActionRuleDto {
 
   private UUID collectionExerciseId;
 
@@ -19,4 +19,6 @@ public class ActionRuleDTO {
   private OffsetDateTime triggerDateTime;
 
   private String phoneNumberColumn;
+
+  private boolean hasTriggered;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/AllowTemplateOnSurvey.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/AllowTemplateOnSurvey.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import java.util.UUID;
 import lombok.Data;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CaseDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CaseDto.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.RefusalType;
+
+@Data
+public class CaseDto {
+  private String collectionExerciseName;
+
+  private Long caseRef;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime lastUpdatedAt;
+  private boolean receiptReceived;
+  private RefusalType refusalReceived;
+  private boolean invalid;
+  private boolean eqLaunched;
+
+  private List<UacQidLinkDto> uacQidLinks;
+  private List<EventDto> events;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class CollectionExerciseDto {
+  private String name;
+  private UUID surveyId;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 @Data
 public class CollectionExerciseDto {
+  private UUID id;
   private String name;
   private UUID surveyId;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EventDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EventDto.java
@@ -1,0 +1,18 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.EventType;
+
+@Data
+public class EventDto {
+  private OffsetDateTime dateTime;
+  private String description;
+  private String channel;
+  private String source;
+  private EventType type;
+  private UUID messageId;
+  private UUID correlationId;
+  private String payload;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/PrintTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/PrintTemplateDto.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import lombok.Data;
+
+@Data
+public class PrintTemplateDto {
+  private String packCode;
+  private String[] template;
+  private String printSupplier;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
@@ -1,0 +1,11 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class SmsTemplateDto {
+  private String packCode;
+  private String[] template;
+  private UUID notifyTemplateId;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SurveyDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SurveyDto.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+
+@Data
+public class SurveyDto {
+  private UUID id;
+  private String name;
+  private ColumnValidator[] sampleValidationRules;
+  private boolean sampleWithHeaderRow;
+  private char sampleSeparator;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UacQidLinkDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UacQidLinkDto.java
@@ -1,0 +1,12 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+public class UacQidLinkDto {
+  private String qid;
+  private boolean active = true;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime lastUpdatedAt;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserDto.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class UserDto {
+  private UUID id;
+  private String email;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupDto.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class UserGroupDto {
+  private UUID id;
+  private String name;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupMemberDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupMemberDto.java
@@ -1,0 +1,12 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class UserGroupMemberDto {
+  private UUID id;
+  private UUID userId;
+  private UUID groupId;
+  private String groupName;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupPermissionDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupPermissionDto.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ssdc.supporttool.model.dto.ui;
+
+import java.util.UUID;
+import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+
+@Data
+public class UserGroupPermissionDto {
+  private UUID id;
+  private UUID groupId;
+  private UUID surveyId;
+  private String surveyName;
+  private UserGroupAuthorisedActivityType authorisedActivity;
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleRepository.java
@@ -1,9 +1,11 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.ActionRule;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
 
-@RepositoryRestResource
-public interface ActionRuleRepository extends JpaRepository<ActionRule, UUID> {}
+public interface ActionRuleRepository extends JpaRepository<ActionRule, UUID> {
+  List<ActionRule> findByCollectionExercise(CollectionExercise collectionExercise);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyPrintTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyPrintTemplateRepository.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveyPrintTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface ActionRuleSurveyPrintTemplateRepository
-    extends PagingAndSortingRepository<ActionRuleSurveyPrintTemplate, UUID> {}
+    extends JpaRepository<ActionRuleSurveyPrintTemplate, UUID> {
+  List<ActionRuleSurveyPrintTemplate> findBySurvey(Survey survey);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface ActionRuleSurveySmsTemplateRepository
-    extends PagingAndSortingRepository<ActionRuleSurveySmsTemplate, UUID> {}
+    extends JpaRepository<ActionRuleSurveySmsTemplate, UUID> {
+  List<ActionRuleSurveySmsTemplate> findBySurvey(Survey survey);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CaseRepository.java
@@ -2,14 +2,12 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.Case;
 
-@RepositoryRestResource
-public interface CaseRepository extends PagingAndSortingRepository<Case, UUID> {
+public interface CaseRepository extends JpaRepository<Case, UUID> {
   Optional<Case> findByCaseRef(@Param("caseRef") Long caseRef);
 
   @Query(

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CollectionExerciseRepository.java
@@ -1,10 +1,7 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
 
-@RepositoryRestResource
-public interface CollectionExerciseRepository
-    extends PagingAndSortingRepository<CollectionExercise, UUID> {}
+public interface CollectionExerciseRepository extends JpaRepository<CollectionExercise, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/CollectionExerciseRepository.java
@@ -1,7 +1,11 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
-public interface CollectionExerciseRepository extends JpaRepository<CollectionExercise, UUID> {}
+public interface CollectionExerciseRepository extends JpaRepository<CollectionExercise, UUID> {
+  List<CollectionExercise> findBySurvey(Survey survey);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentNextTriggerRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentNextTriggerRepository.java
@@ -1,10 +1,8 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentNextTrigger;
 
-@RepositoryRestResource
 public interface FulfilmentNextTriggerRepository
-    extends PagingAndSortingRepository<FulfilmentNextTrigger, UUID> {}
+    extends JpaRepository<FulfilmentNextTrigger, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyPrintTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyPrintTemplateRepository.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyPrintTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface FulfilmentSurveyPrintTemplateRepository
-    extends PagingAndSortingRepository<FulfilmentSurveyPrintTemplate, UUID> {}
+    extends JpaRepository<FulfilmentSurveyPrintTemplate, UUID> {
+  List<FulfilmentSurveyPrintTemplate> findBySurvey(Survey survey);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyPrintTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyPrintTemplateRepository.java
@@ -2,9 +2,7 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyPrintTemplate;
 
-@RepositoryRestResource
 public interface FulfilmentSurveyPrintTemplateRepository
     extends PagingAndSortingRepository<FulfilmentSurveyPrintTemplate, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
@@ -2,9 +2,7 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveySmsTemplate;
 
-@RepositoryRestResource
 public interface FulfilmentSurveySmsTemplateRepository
     extends PagingAndSortingRepository<FulfilmentSurveySmsTemplate, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface FulfilmentSurveySmsTemplateRepository
-    extends PagingAndSortingRepository<FulfilmentSurveySmsTemplate, UUID> {}
+    extends JpaRepository<FulfilmentSurveySmsTemplate, UUID> {
+  List<FulfilmentSurveySmsTemplate> findBySurvey(Survey survey);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/PrintTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/PrintTemplateRepository.java
@@ -1,9 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.PrintTemplate;
 
-@RepositoryRestResource
-public interface PrintTemplateRepository
-    extends PagingAndSortingRepository<PrintTemplate, String> {}
+public interface PrintTemplateRepository extends JpaRepository<PrintTemplate, String> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SmsTemplateRepository.java
@@ -1,8 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 
 public interface SmsTemplateRepository extends JpaRepository<SmsTemplate, String> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SmsTemplateRepository.java
@@ -1,8 +1,8 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 
-@RepositoryRestResource
-public interface SmsTemplateRepository extends PagingAndSortingRepository<SmsTemplate, String> {}
+public interface SmsTemplateRepository extends JpaRepository<SmsTemplate, String> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SurveyRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/SurveyRepository.java
@@ -1,9 +1,7 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
-@RepositoryRestResource
-public interface SurveyRepository extends PagingAndSortingRepository<Survey, UUID> {}
+public interface SurveyRepository extends JpaRepository<Survey, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UacQidLinkRepository.java
@@ -2,11 +2,9 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.UacQidLink;
 
-@RepositoryRestResource
-public interface UacQidLinkRepository extends PagingAndSortingRepository<UacQidLink, UUID> {
+public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {
   Optional<UacQidLink> findByQid(String qid);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupMemberRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupMemberRepository.java
@@ -1,9 +1,11 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import uk.gov.ons.ssdc.common.model.entity.User;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupMember;
 
-@RepositoryRestResource
-public interface UserGroupMemberRepository extends JpaRepository<UserGroupMember, UUID> {}
+public interface UserGroupMemberRepository extends JpaRepository<UserGroupMember, UUID> {
+  List<UserGroupMember> findByUser(User user);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupPermissionRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupPermissionRepository.java
@@ -3,11 +3,9 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.UserGroup;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupPermission;
 
-@RepositoryRestResource
 public interface UserGroupPermissionRepository extends JpaRepository<UserGroupPermission, UUID> {
   List<UserGroupPermission> findByGroup(UserGroup group);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupPermissionRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupPermissionRepository.java
@@ -1,9 +1,13 @@
 package uk.gov.ons.ssdc.supporttool.model.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupPermission;
 
 @RepositoryRestResource
-public interface UserGroupPermissionRepository extends JpaRepository<UserGroupPermission, UUID> {}
+public interface UserGroupPermissionRepository extends JpaRepository<UserGroupPermission, UUID> {
+  List<UserGroupPermission> findByGroup(UserGroup group);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupRepository.java
@@ -2,8 +2,6 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.UserGroup;
 
-@RepositoryRestResource
 public interface UserGroupRepository extends JpaRepository<UserGroup, UUID> {}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserRepository.java
@@ -3,10 +3,8 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.ssdc.common.model.entity.User;
 
-@RepositoryRestResource
 public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -60,8 +60,9 @@ public class UserIdentity {
                     && permission.getSurvey().getId().equals(survey.getId())
                 // Otherwise, user must have specific activity/survey combo to be authorised
                 || (permission.getAuthorisedActivity() == activity
-                    && permission.getSurvey() != null
-                    && permission.getSurvey().getId().equals(survey.getId())))) {
+                    && (permission.getSurvey() == null
+                        || (permission.getSurvey() != null
+                            && permission.getSurvey().getId().equals(survey.getId())))))) {
           return; // User is authorised
         }
       }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,12 +45,6 @@ spring:
     serialization:
       FAIL_ON_EMPTY_BEANS: false
 
-  cloud:
-    gcp:
-      pubsub:
-        emulator-host: localhost:8538
-        project-id: our-project
-
 logging:
   level:
     ROOT: INFO
@@ -86,7 +80,7 @@ queueconfig:
   invalid-case-event-topic: event_invalid-case
   update-sample-sensitive-topic: event_update-sample-sensitive
   publishtimeout: 30  # In seconds
-  shared-pubsub-project: shared-project
+  shared-pubsub-project: REPLACEME
 
 file-upload-storage-path: /tmp/
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,12 @@ spring:
     serialization:
       FAIL_ON_EMPTY_BEANS: false
 
+  cloud:
+    gcp:
+      pubsub:
+        emulator-host: localhost:8538
+        project-id: our-project
+
 logging:
   level:
     ROOT: INFO
@@ -80,7 +86,7 @@ queueconfig:
   invalid-case-event-topic: event_invalid-case
   update-sample-sensitive-topic: event_update-sample-sensitive
   publishtimeout: 30  # In seconds
-  shared-pubsub-project: REPLACEME
+  shared-pubsub-project: shared-project
 
 file-upload-storage-path: /tmp/
 

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -1,29 +1,28 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.testhelper.IntegrationTestHelper;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-public class WhoAmIEndpointIT {
+public class AllEndpointsIT {
+  @Autowired private IntegrationTestHelper integrationTestHelper;
 
   @LocalServerPort private int port;
 
   @Test
-  public void testWhoAmI() {
-    RestTemplate restTemplate = new RestTemplate();
-    String url = "http://localhost:" + port + "/api/whoami";
-    ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
-    assertThat(response.getBody().get("user")).isEqualTo("dummy@fake-email.com");
+  public void testAllTheEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_ACTION_RULES,
+        (bundle) -> String.format("actionRules/?collectionExercise=%s", bundle.getCollexId()));
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/WhoAmIEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/WhoAmIEndpointIT.java
@@ -1,0 +1,29 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class WhoAmIEndpointIT {
+
+  @LocalServerPort private int port;
+
+  @Test
+  public void testWhoAmI() {
+    RestTemplate restTemplate = new RestTemplate();
+    String url = "http://localhost:" + port + "/api/whoami";
+    ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+    assertThat(response.getBody().get("user")).isEqualTo("dummy@fake-email.com");
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleFunction.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleFunction.java
@@ -1,0 +1,6 @@
+package uk.gov.ons.ssdc.supporttool.testhelper;
+
+@FunctionalInterface
+public interface BundleFunction {
+  String getUrl(BundleOfUsefulTestStuff bundle);
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ssdc.supporttool.testhelper;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class BundleOfUsefulTestStuff {
+  private UUID surveyId;
+  private UUID collexId;
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -1,0 +1,128 @@
+package uk.gov.ons.ssdc.supporttool.testhelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.common.model.entity.User;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupMember;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupPermission;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.supporttool.model.repository.CollectionExerciseRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupMemberRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupPermissionRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserRepository;
+
+@Component
+@ActiveProfiles("test")
+public class IntegrationTestHelper {
+  private static final RestTemplate restTemplate = new RestTemplate();
+
+  private final SurveyRepository surveyRepository;
+  private final CollectionExerciseRepository collectionExerciseRepository;
+  private final UserRepository userRepository;
+  private final UserGroupRepository userGroupRepository;
+  private final UserGroupMemberRepository userGroupMemberRepository;
+  private final UserGroupPermissionRepository userGroupPermissionRepository;
+
+  public IntegrationTestHelper(
+      SurveyRepository surveyRepository,
+      CollectionExerciseRepository collectionExerciseRepository,
+      UserRepository userRepository,
+      UserGroupRepository userGroupRepository,
+      UserGroupMemberRepository userGroupMemberRepository,
+      UserGroupPermissionRepository userGroupPermissionRepository) {
+    this.surveyRepository = surveyRepository;
+    this.collectionExerciseRepository = collectionExerciseRepository;
+    this.userRepository = userRepository;
+    this.userGroupRepository = userGroupRepository;
+    this.userGroupMemberRepository = userGroupMemberRepository;
+    this.userGroupPermissionRepository = userGroupPermissionRepository;
+  }
+
+  public void testGet(
+      int port, UserGroupAuthorisedActivityType activity, BundleFunction bundleFunction) {
+    BundleOfUsefulTestStuff bundle = getTestBundle();
+    setUpTestUserPermission(activity);
+
+    String url = String.format("http://localhost:%d/api/%s", port, bundleFunction.getUrl(bundle));
+    ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+    assertThat(response.getStatusCodeValue()).isBetween(200, 299);
+
+    deleteAllPermissions();
+
+    try {
+      restTemplate.getForEntity(url, String.class);
+      fail("API call was not forbidden, but should have been");
+    } catch (HttpClientErrorException expectedException) {
+      assertThat(expectedException.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+  }
+
+  private BundleOfUsefulTestStuff getTestBundle() {
+    Survey survey = new Survey();
+    survey.setId(UUID.randomUUID());
+    survey.setName("Test");
+    survey.setSampleWithHeaderRow(true);
+    survey.setSampleValidationRules(new ColumnValidator[] {});
+    survey.setSampleSeparator(',');
+    survey = surveyRepository.saveAndFlush(survey);
+
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    collectionExercise.setSurvey(survey);
+    collectionExercise.setName("Test");
+    collectionExercise = collectionExerciseRepository.saveAndFlush(collectionExercise);
+
+    BundleOfUsefulTestStuff bundle = new BundleOfUsefulTestStuff();
+    bundle.setSurveyId(survey.getId());
+    bundle.setCollexId(collectionExercise.getId());
+
+    return bundle;
+  }
+
+  private void deleteAllPermissions() {
+    userGroupPermissionRepository.deleteAllInBatch();
+    userGroupMemberRepository.deleteAllInBatch();
+    userGroupRepository.deleteAllInBatch();
+    userRepository.deleteAllInBatch();
+  }
+
+  private void setUpTestUserPermission(UserGroupAuthorisedActivityType authorisedActivity) {
+    deleteAllPermissions();
+
+    User user = new User();
+    user.setId(UUID.randomUUID());
+    user.setEmail("integration-tests@testymctest.com");
+    userRepository.saveAndFlush(user);
+
+    UserGroup group = new UserGroup();
+    group.setId(UUID.randomUUID());
+    group.setName("Test group");
+    userGroupRepository.saveAndFlush(group);
+
+    UserGroupMember userGroupMember = new UserGroupMember();
+    userGroupMember.setId(UUID.randomUUID());
+    userGroupMember.setUser(user);
+    userGroupMember.setGroup(group);
+    userGroupMemberRepository.saveAndFlush(userGroupMember);
+
+    UserGroupPermission permission = new UserGroupPermission();
+    permission.setId(UUID.randomUUID());
+    permission.setAuthorisedActivity(authorisedActivity);
+    permission.setGroup(group);
+    userGroupPermissionRepository.saveAndFlush(permission);
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,5 @@ spring:
 queueconfig:
   shared-pubsub-project: shared-project
 
+dummyuseridentity: integration-tests@testymctest.com
+

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -2,12 +2,10 @@ version: '2.1'
 services:
   postgres:
     container_name: postgres-support-tool-it
-    image: postgres:13
+    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-dev-common-postgres:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
       - "16432:5432"
-    environment:
-      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -34,7 +34,6 @@ class CaseDetails extends Component {
 
   componentDidMount() {
     this.getSurveyName(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getCollexName(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     this.getCasesAndQidData();
 
@@ -51,18 +50,6 @@ class CaseDetails extends Component {
     const surveyJson = await response.json();
 
     this.setState({ surveyName: surveyJson.name });
-  };
-
-  getCollexName = async () => {
-    const collexResponse = await fetch(
-      `/api/cases/${this.props.caseId}/collectionExercise`
-    );
-
-    const collexJson = await collexResponse.json();
-
-    this.setState({
-      collexName: collexJson.name,
-    });
   };
 
   getAuthorisedActivities = async () => {
@@ -83,27 +70,11 @@ class CaseDetails extends Component {
     const caseJson = await response.json();
 
     if (response.ok) {
-      this.setState({ case: caseJson });
-
-      const uacQidLinksResponse = await fetch(
-        `/api/cases/${this.props.caseId}/uacQidLinks`
-      );
-      const uacQidLinksJson = await uacQidLinksResponse.json();
-
-      const uacQidLinks = uacQidLinksJson._embedded.uacQidLinks;
-
-      let events = caseJson.events;
-      for (let i = 0; i < uacQidLinks.length; i++) {
-        events = events.concat(uacQidLinks[i].events);
-      }
-
-      if (uacQidLinksResponse.ok) {
         this.setState({
           case: caseJson,
-          uacQidLinks: uacQidLinks,
-          events: events,
+          uacQidLinks: caseJson.uacQidLinks,
+          events: caseJson.events,
         });
-      }
     }
   };
 
@@ -199,7 +170,7 @@ class CaseDetails extends Component {
                   <TableCell component="th" scope="row">
                     <div>Case ref: {this.state.case.caseRef}</div>
                     <div>Survey name: {this.state.surveyName}</div>
-                    <div>Collection Exercise name: {this.state.collexName}</div>
+                    <div>Collection Exercise name: {this.state.case.collectionExerciseName}</div>
                     <div>Created at: {this.state.case.createdAt}</div>
                     <div>Last updated at: {this.state.case.lastUpdatedAt}</div>
                     <div>

--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -70,11 +70,11 @@ class CaseDetails extends Component {
     const caseJson = await response.json();
 
     if (response.ok) {
-        this.setState({
-          case: caseJson,
-          uacQidLinks: caseJson.uacQidLinks,
-          events: caseJson.events,
-        });
+      this.setState({
+        case: caseJson,
+        uacQidLinks: caseJson.uacQidLinks,
+        events: caseJson.events,
+      });
     }
   };
 
@@ -170,7 +170,10 @@ class CaseDetails extends Component {
                   <TableCell component="th" scope="row">
                     <div>Case ref: {this.state.case.caseRef}</div>
                     <div>Survey name: {this.state.surveyName}</div>
-                    <div>Collection Exercise name: {this.state.case.collectionExerciseName}</div>
+                    <div>
+                      Collection Exercise name:{" "}
+                      {this.state.case.collectionExerciseName}
+                    </div>
                     <div>Created at: {this.state.case.createdAt}</div>
                     <div>Last updated at: {this.state.case.lastUpdatedAt}</div>
                     <div>

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -103,7 +103,7 @@ class CollectionExerciseDetails extends Component {
     const actionRuleJson = await response.json();
 
     this.setState({
-      actionRules: actionRuleJson
+      actionRules: actionRuleJson,
     });
   };
 

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -349,20 +349,22 @@ class CollectionExerciseDetails extends Component {
             </Button>
           </div>
         )}
-        <TableContainer component={Paper} style={{ marginTop: 20 }}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Type</TableCell>
-                <TableCell>Trigger date</TableCell>
-                <TableCell>Has triggered?</TableCell>
-                <TableCell>Classifiers</TableCell>
-                <TableCell>Pack Code</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>{actionRuleTableRows}</TableBody>
-          </Table>
-        </TableContainer>
+        {this.state.authorisedActivities.includes("LIST_ACTION_RULES") && (
+          <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Type</TableCell>
+                  <TableCell>Trigger date</TableCell>
+                  <TableCell>Has triggered?</TableCell>
+                  <TableCell>Classifiers</TableCell>
+                  <TableCell>Pack Code</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>{actionRuleTableRows}</TableBody>
+            </Table>
+          </TableContainer>
+        )}
         {(this.state.authorisedActivities.includes("LOAD_SAMPLE") ||
           this.state.authorisedActivities.includes(
             "VIEW_SAMPLE_LOAD_PROGRESS"

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -31,10 +31,8 @@ class CollectionExerciseDetails extends Component {
     authorisedActivities: [],
     actionRules: [],
     printPackCodes: [],
-    printTemplateHrefToPackCodeMap: new Map(),
     sensitiveSampleColumns: [],
     smsPackCodes: [],
-    smsTemplateHrefToPackCodeMap: new Map(),
     createActionRulesDialogDisplayed: false,
     printPackCodeValidationError: false,
     smsPackCodeValidationError: false,
@@ -100,44 +98,12 @@ class CollectionExerciseDetails extends Component {
 
   getActionRules = async () => {
     const response = await fetch(
-      `/api/collectionExercises/${this.props.collectionExerciseId}/actionRules`
+      `/api/actionRules/?collectionExercise=${this.props.collectionExerciseId}`
     );
     const actionRuleJson = await response.json();
-    const actionRules = actionRuleJson._embedded.actionRules;
-
-    let printTemplateHrefToPackCodeMap = new Map();
-    let smsTemplateHrefToPackCodeMap = new Map();
-
-    for (let i = 0; i < actionRules.length; i++) {
-      if (actionRules[i].type === "PRINT") {
-        const printTemplateUrl = new URL(
-          actionRules[i]._links.printTemplate.href
-        );
-        const printTemplateResponse = await fetch(printTemplateUrl.pathname);
-        const printTemplateJson = await printTemplateResponse.json();
-        const packCode = printTemplateJson._links.self.href.split("/").pop();
-
-        printTemplateHrefToPackCodeMap.set(
-          actionRules[i]._links.printTemplate.href,
-          packCode
-        );
-      } else if (actionRules[i].type === "SMS") {
-        const smsTemplateUrl = new URL(actionRules[i]._links.smsTemplate.href);
-        const smsTemplateResponse = await fetch(smsTemplateUrl.pathname);
-        const smsTemplateJson = await smsTemplateResponse.json();
-        const packCode = smsTemplateJson._links.self.href.split("/").pop();
-
-        smsTemplateHrefToPackCodeMap.set(
-          actionRules[i]._links.smsTemplate.href,
-          packCode
-        );
-      }
-    }
 
     this.setState({
-      actionRules: actionRules,
-      printTemplateHrefToPackCodeMap: printTemplateHrefToPackCodeMap,
-      smsTemplateHrefToPackCodeMap: smsTemplateHrefToPackCodeMap,
+      actionRules: actionRuleJson
     });
   };
 
@@ -288,18 +254,6 @@ class CollectionExerciseDetails extends Component {
   render() {
     const actionRuleTableRows = this.state.actionRules.map(
       (actionRule, index) => {
-        let packCode = "";
-
-        if (actionRule.type === "PRINT") {
-          packCode = this.state.printTemplateHrefToPackCodeMap.get(
-            actionRule._links.printTemplate.href
-          );
-        } else if (actionRule.type === "SMS") {
-          packCode = this.state.smsTemplateHrefToPackCodeMap.get(
-            actionRule._links.smsTemplate.href
-          );
-        }
-
         return (
           <TableRow key={index}>
             <TableCell component="th" scope="row">
@@ -315,7 +269,7 @@ class CollectionExerciseDetails extends Component {
               {actionRule.classifiers}
             </TableCell>
             <TableCell component="th" scope="row">
-              {packCode}
+              {actionRule.packCode}
             </TableCell>
           </TableRow>
         );

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -169,10 +169,10 @@ class GroupDetails extends Component {
     }
 
     const newUserGroupPermission = {
-        authorisedActivity: this.state.activity,
-        groupId: this.props.groupId,
-        surveyId: this.state.surveyId,
-      };
+      authorisedActivity: this.state.activity,
+      groupId: this.props.groupId,
+      surveyId: this.state.surveyId,
+    };
 
     await fetch("/api/userGroupPermissions", {
       method: "POST",
@@ -186,7 +186,9 @@ class GroupDetails extends Component {
   render() {
     const groupActivitiesTableRows = this.state.groupActivities.map(
       (groupActivity, index) => {
-        const surveyName = groupActivity.surveyId ? groupActivity.surveyName : "All Surveys - Global permission";
+        const surveyName = groupActivity.surveyId
+          ? groupActivity.surveyName
+          : "All Surveys - Global permission";
 
         return (
           <TableRow key={index}>
@@ -223,13 +225,11 @@ class GroupDetails extends Component {
       );
     });
 
-    const surveyMenuItems = this.state.allSurveys.map((survey) =>
-      (
-        <MenuItem key={survey.id} value={survey.id}>
-          {survey.name}
-        </MenuItem>
-      )
-    );
+    const surveyMenuItems = this.state.allSurveys.map((survey) => (
+      <MenuItem key={survey.id} value={survey.id}>
+        {survey.name}
+      </MenuItem>
+    ));
 
     return (
       <div style={{ padding: 20 }}>

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -504,50 +504,50 @@ class LandingPage extends Component {
           </TableContainer>
         )}
         {this.state.authorisedActivities.includes("CREATE_PRINT_TEMPLATE") && (
-          <div>
-            <Button
-              variant="contained"
-              onClick={this.openPrintTemplateDialog}
-              style={{ marginTop: 20 }}
-            >
-              Create Print Template
-            </Button>
-            <TableContainer component={Paper} style={{ marginTop: 20 }}>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Pack Code</TableCell>
-                    <TableCell>Print Supplier</TableCell>
-                    <TableCell>Template</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>{printTemplateRows}</TableBody>
-              </Table>
-            </TableContainer>
-          </div>
+          <Button
+            variant="contained"
+            onClick={this.openPrintTemplateDialog}
+            style={{ marginTop: 20 }}
+          >
+            Create Print Template
+          </Button>
+        )}
+        {this.state.authorisedActivities.includes("LIST_PRINT_TEMPLATES") && (
+          <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Pack Code</TableCell>
+                  <TableCell>Print Supplier</TableCell>
+                  <TableCell>Template</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>{printTemplateRows}</TableBody>
+            </Table>
+          </TableContainer>
         )}
 
         {this.state.authorisedActivities.includes("CREATE_SMS_TEMPLATE") && (
-          <div>
-            <Button
-              variant="contained"
-              onClick={this.openSmsTemplateDialog}
-              style={{ marginTop: 20 }}
-            >
-              Create sms Template
-            </Button>
-            <TableContainer component={Paper} style={{ marginTop: 20 }}>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Pack Code</TableCell>
-                    <TableCell>Template</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>{smsTemplateRows}</TableBody>
-              </Table>
-            </TableContainer>
-          </div>
+          <Button
+            variant="contained"
+            onClick={this.openSmsTemplateDialog}
+            style={{ marginTop: 20 }}
+          >
+            Create sms Template
+          </Button>
+        )}
+        {this.state.authorisedActivities.includes("LIST_SMS_TEMPLATES") && (
+          <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Pack Code</TableCell>
+                  <TableCell>Template</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>{smsTemplateRows}</TableBody>
+            </Table>
+          </TableContainer>
         )}
         {this.state.authorisedActivities.includes(
           "CONFIGURE_FULFILMENT_TRIGGER"

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -17,7 +17,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { uuidv4 } from "./common";
 import { Link } from "react-router-dom";
 
 class LandingPage extends Component {
@@ -100,7 +99,7 @@ class LandingPage extends Component {
     const response = await fetch("/api/surveys");
     const surveyJson = await response.json();
 
-    this.setState({ surveys: surveyJson._embedded.surveys });
+    this.setState({ surveys: surveyJson });
   };
 
   getDateTimeForDateTimePicker = (date) => {
@@ -257,7 +256,6 @@ class LandingPage extends Component {
     }
 
     const newSurvey = {
-      id: uuidv4(),
       name: this.state.newSurveyName,
       sampleValidationRules: JSON.parse(this.state.newSurveyValidationRules),
       sampleWithHeaderRow: this.state.newSurveyHeaderRow,
@@ -447,17 +445,14 @@ class LandingPage extends Component {
   };
 
   render() {
-    const surveyTableRows = this.state.surveys.map((survey) => {
-      const surveyId = survey._links.self.href.split("/").pop();
-
-      return (
+    const surveyTableRows = this.state.surveys.map((survey) => (
         <TableRow key={survey.name}>
           <TableCell component="th" scope="row">
-            <Link to={`/survey?surveyId=${surveyId}`}>{survey.name}</Link>
+            <Link to={`/survey?surveyId=${survey.id}`}>{survey.name}</Link>
           </TableCell>
         </TableRow>
-      );
-    });
+      )
+    );
 
     const printTemplateRows = this.state.printTemplates.map((printTemplate) => (
         <TableRow key={printTemplate.packCode}>

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -108,9 +108,7 @@ class LandingPage extends Component {
   };
 
   getFulfilmentTrigger = async () => {
-    const response = await fetch(
-      `/api/fulfilmentNextTriggers`
-    );
+    const response = await fetch(`/api/fulfilmentNextTriggers`);
 
     if (!response.ok) {
       this.setState({
@@ -280,9 +278,12 @@ class LandingPage extends Component {
       this.state.nextFulfilmentTriggerDateTime
     ).toISOString();
 
-    const response = await fetch(`/api/fulfilmentNextTriggers/?triggerDateTime=${triggerDateTime}`, {
-      method: "POST"
-    });
+    const response = await fetch(
+      `/api/fulfilmentNextTriggers/?triggerDateTime=${triggerDateTime}`,
+      {
+        method: "POST",
+      }
+    );
 
     if (response.ok) {
       this.setState({ configureNextTriggerDisplayed: false });
@@ -446,40 +447,36 @@ class LandingPage extends Component {
 
   render() {
     const surveyTableRows = this.state.surveys.map((survey) => (
-        <TableRow key={survey.name}>
-          <TableCell component="th" scope="row">
-            <Link to={`/survey?surveyId=${survey.id}`}>{survey.name}</Link>
-          </TableCell>
-        </TableRow>
-      )
-    );
+      <TableRow key={survey.name}>
+        <TableCell component="th" scope="row">
+          <Link to={`/survey?surveyId=${survey.id}`}>{survey.name}</Link>
+        </TableCell>
+      </TableRow>
+    ));
 
     const printTemplateRows = this.state.printTemplates.map((printTemplate) => (
-        <TableRow key={printTemplate.packCode}>
-          <TableCell component="th" scope="row">
-            {printTemplate.packCode}
-          </TableCell>
-          <TableCell component="th" scope="row">
-            {printTemplate.printSupplier}
-          </TableCell>
-          <TableCell component="th" scope="row">
-            {JSON.stringify(printTemplate.template)}
-          </TableCell>
-        </TableRow>
-      )
-    );
-    const smsTemplateRows = this.state.smsTemplates.map((smsTemplate) =>
-       (
-        <TableRow key={smsTemplate.packCode}>
-          <TableCell component="th" scope="row">
-            {smsTemplate.packCode}
-          </TableCell>
-          <TableCell component="th" scope="row">
-            {JSON.stringify(smsTemplate.template)}
-          </TableCell>
-        </TableRow>
-      )
-    );
+      <TableRow key={printTemplate.packCode}>
+        <TableCell component="th" scope="row">
+          {printTemplate.packCode}
+        </TableCell>
+        <TableCell component="th" scope="row">
+          {printTemplate.printSupplier}
+        </TableCell>
+        <TableCell component="th" scope="row">
+          {JSON.stringify(printTemplate.template)}
+        </TableCell>
+      </TableRow>
+    ));
+    const smsTemplateRows = this.state.smsTemplates.map((smsTemplate) => (
+      <TableRow key={smsTemplate.packCode}>
+        <TableCell component="th" scope="row">
+          {smsTemplate.packCode}
+        </TableCell>
+        <TableCell component="th" scope="row">
+          {JSON.stringify(smsTemplate.template)}
+        </TableCell>
+      </TableRow>
+    ));
 
     const printSupplierMenuItems = this.state.printSuppliers.map((supplier) => (
       <MenuItem key={supplier} value={supplier}>
@@ -552,16 +549,18 @@ class LandingPage extends Component {
             </TableContainer>
           </div>
         )}
-        {this.state.authorisedActivities.includes("CONFIGURE_FULFILMENT_TRIGGER") && (
-        <div>
-          <Button
-            variant="contained"
-            onClick={this.openFulfilmentTriggerDialog}
-            style={{ marginTop: 20 }}
-          >
-            Configure fulfilment trigger
-          </Button>
-        </div>
+        {this.state.authorisedActivities.includes(
+          "CONFIGURE_FULFILMENT_TRIGGER"
+        ) && (
+          <div>
+            <Button
+              variant="contained"
+              onClick={this.openFulfilmentTriggerDialog}
+              style={{ marginTop: 20 }}
+            >
+              Configure fulfilment trigger
+            </Button>
+          </div>
         )}
         {this.state.authorisedActivities.includes("SUPER_USER") && (
           <>

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -87,18 +87,19 @@ class SampleUpload extends Component {
           body: jobData,
         });
 
-        if (response.ok) {
-          // Hide the progress dialog and flash the snackbar message
-          this.setState({
-            fileProgress: 1.0,
-            fileUploadSuccess: true,
-            uploadInProgress: false,
-          });
-
-          this.getJobs();
-        } else {
+        if (!response.ok) {
           // TODO - nice error handling
+          // If we check it, it's is currently buggy and leaves the popup on the screen for unknown reasons - need to raise a defect
         }
+
+        // Hide the progress dialog and flash the snackbar message
+        this.setState({
+          fileProgress: 1.0,
+          fileUploadSuccess: true,
+          uploadInProgress: false,
+        });
+
+        this.getJobs();
       });
   };
 

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -87,14 +87,18 @@ class SampleUpload extends Component {
           body: jobData,
         });
 
-        // Hide the progress dialog and flash the snackbar message
-        this.setState({
-          fileProgress: 1.0,
-          fileUploadSuccess: true,
-          uploadInProgress: false,
-        });
+        if (response.ok) {
+          // Hide the progress dialog and flash the snackbar message
+          this.setState({
+            fileProgress: 1.0,
+            fileUploadSuccess: true,
+            uploadInProgress: false,
+          });
 
-        this.getJobs();
+          this.getJobs();
+        } else {
+          // TODO - nice error handling
+        }
       });
   };
 

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -44,12 +44,12 @@ class SurveyCaseSearch extends Component {
 
   getCollectionExercises = async () => {
     const response = await fetch(
-      `/api/surveys/${this.props.surveyId}/collectionExercises`
+      `/api/collectionExercises/?surveyId=${this.props.surveyId}`
     );
     const collexJson = await response.json();
 
     this.setState({
-      collectionExercises: collexJson._embedded.collectionExercises,
+      collectionExercises: collexJson,
     });
   };
 

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -18,7 +18,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { uuidv4 } from "./common";
 import {
   getActionRulePrintTemplates,
   getActionRuleSmsTemplates,
@@ -184,7 +183,6 @@ class SurveyDetails extends Component {
     }
 
     const newCollectionExercise = {
-      id: uuidv4(),
       name: this.state.newCollectionExerciseName,
       surveyId: this.props.surveyId,
     };
@@ -383,16 +381,16 @@ class SurveyDetails extends Component {
   render() {
     const collectionExerciseTableRows = this.state.collectionExercises.map(
       (collex) => (
-          <TableRow key={collex.name}>
-            <TableCell component="th" scope="row">
-              <Link
-                to={`/collex?surveyId=${this.props.surveyId}&collexId=${collex.id}`}
-              >
-                {collex.name}
-              </Link>
-            </TableCell>
-          </TableRow>
-        )
+        <TableRow key={collex.name}>
+          <TableCell component="th" scope="row">
+            <Link
+              to={`/collex?surveyId=${this.props.surveyId}&collexId=${collex.id}`}
+            >
+              {collex.name}
+            </Link>
+          </TableCell>
+        </TableRow>
+      )
     );
 
     const actionRulePrintTemplateTableRows =

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -148,12 +148,12 @@ class SurveyDetails extends Component {
 
   getCollectionExercises = async () => {
     const response = await fetch(
-      `/api/surveys/${this.props.surveyId}/collectionExercises`
+      `/api/collectionExercises/?surveyId=${this.props.surveyId}`
     );
     const collexJson = await response.json();
 
     this.setState({
-      collectionExercises: collexJson._embedded.collectionExercises,
+      collectionExercises: collexJson,
     });
   };
 
@@ -382,21 +382,17 @@ class SurveyDetails extends Component {
 
   render() {
     const collectionExerciseTableRows = this.state.collectionExercises.map(
-      (collex) => {
-        const collexId = collex._links.self.href.split("/").pop();
-
-        return (
+      (collex) => (
           <TableRow key={collex.name}>
             <TableCell component="th" scope="row">
               <Link
-                to={`/collex?surveyId=${this.props.surveyId}&collexId=${collexId}`}
+                to={`/collex?surveyId=${this.props.surveyId}&collexId=${collex.id}`}
               >
                 {collex.name}
               </Link>
             </TableCell>
           </TableRow>
-        );
-      }
+        )
     );
 
     const actionRulePrintTemplateTableRows =

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -186,7 +186,7 @@ class SurveyDetails extends Component {
     const newCollectionExercise = {
       id: uuidv4(),
       name: this.state.newCollectionExerciseName,
-      survey: "surveys/" + this.props.surveyId,
+      surveyId: this.props.surveyId,
     };
 
     const response = await fetch("/api/collectionExercises", {
@@ -336,9 +336,8 @@ class SurveyDetails extends Component {
     }
 
     const newAllowSmsTemplate = {
-      id: uuidv4(),
-      survey: "surveys/" + this.props.surveyId,
-      smsTemplate: "smsTemplates/" + this.state.smsTemplateToAllow,
+      surveyId: this.props.surveyId,
+      packCode: this.state.smsTemplateToAllow,
     };
 
     const response = await fetch("/api/fulfilmentSurveySmsTemplates", {

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -119,10 +119,7 @@ class SurveySampleSearch extends Component {
     collectionExerciseMenuItems.push(noFilterMenuItem);
     collectionExerciseMenuItems.push(
       this.props.collectionExercises.map((collex) => (
-        <MenuItem
-          key={collex.name}
-          value={collex.id}
-        >
+        <MenuItem key={collex.name} value={collex.id}>
           {collex.name}
         </MenuItem>
       ))

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -121,7 +121,7 @@ class SurveySampleSearch extends Component {
       this.props.collectionExercises.map((collex) => (
         <MenuItem
           key={collex.name}
-          value={collex._links.self.href.split("/").pop()}
+          value={collex.id}
         >
           {collex.name}
         </MenuItem>

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -14,7 +14,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { uuidv4 } from "./common";
 
 class UserAdmin extends Component {
   state = {
@@ -52,7 +51,7 @@ class UserAdmin extends Component {
     const usersJson = await usersResponse.json();
 
     this.setState({
-      users: usersJson._embedded.users,
+      users: usersJson,
     });
   };
 
@@ -62,7 +61,7 @@ class UserAdmin extends Component {
     const groupsJson = await groupsResponse.json();
 
     this.setState({
-      groups: groupsJson._embedded.userGroups,
+      groups: groupsJson,
     });
   };
 
@@ -108,7 +107,6 @@ class UserAdmin extends Component {
     }
 
     const newUser = {
-      id: uuidv4(),
       email: this.state.email,
     };
 
@@ -148,7 +146,6 @@ class UserAdmin extends Component {
     }
 
     const newGroup = {
-      id: uuidv4(),
       name: this.state.groupName,
     };
 
@@ -162,25 +159,20 @@ class UserAdmin extends Component {
   };
 
   render() {
-    const usersTableRows = this.state.users.map((user) => {
-      const userId = user._links.self.href.split("/").pop();
-
-      return (
+    const usersTableRows = this.state.users.map((user) => (
         <TableRow key={user.email}>
           <TableCell component="th" scope="row">
-            <Link to={`/userDetails?userId=${userId}`}>{user.email}</Link>
+            <Link to={`/userDetails?userId=${user.id}`}>{user.email}</Link>
           </TableCell>
         </TableRow>
-      );
-    });
+      )
+    );
 
-    const groupsTableRows = this.state.groups.map((group, index) => {
-      const groupId = group._links.self.href.split("/").pop();
-
+    const groupsTableRows = this.state.groups.map((group) => {
       return (
-        <TableRow key={groupId}>
+        <TableRow key={group.id}>
           <TableCell component="th" scope="row">
-            <Link to={`/groupDetails?groupId=${groupId}`}>{group.name}</Link>
+            <Link to={`/groupDetails?groupId=${group.id}`}>{group.name}</Link>
           </TableCell>
         </TableRow>
       );

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -160,13 +160,12 @@ class UserAdmin extends Component {
 
   render() {
     const usersTableRows = this.state.users.map((user) => (
-        <TableRow key={user.email}>
-          <TableCell component="th" scope="row">
-            <Link to={`/userDetails?userId=${user.id}`}>{user.email}</Link>
-          </TableCell>
-        </TableRow>
-      )
-    );
+      <TableRow key={user.email}>
+        <TableCell component="th" scope="row">
+          <Link to={`/userDetails?userId=${user.id}`}>{user.email}</Link>
+        </TableCell>
+      </TableRow>
+    ));
 
     const groupsTableRows = this.state.groups.map((group) => {
       return (

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -189,11 +189,10 @@ class UserDetails extends Component {
     );
 
     const groupMenuItems = this.state.groups.map((group) => (
-        <MenuItem key={group.id} value={group.id}>
-          {group.name}
-        </MenuItem>
-      )
-    );
+      <MenuItem key={group.id} value={group.id}>
+        {group.name}
+      </MenuItem>
+    ));
 
     return (
       <div style={{ padding: 20 }}>

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -18,102 +18,36 @@ export const getAllSmsTemplates = async () => {
 
 export const getFulfilmentPrintTemplates = async (surveyId) => {
   const response = await fetch(
-    `/api/surveys/${surveyId}/fulfilmentPrintTemplates`
+    `/api/fulfilmentSurveyPrintTemplates/?surveyId=${surveyId}`
   );
   const printTemplatesJson = await response.json();
-  const printTemplates =
-    printTemplatesJson._embedded.fulfilmentSurveyPrintTemplates;
 
-  let templates = [];
-
-  for (let i = 0; i < printTemplates.length; i++) {
-    const printTemplateUrl = new URL(
-      printTemplates[i]._links.printTemplate.href
-    );
-
-    const printTemplateResponse = await fetch(printTemplateUrl.pathname);
-    const printTemplateJson = await printTemplateResponse.json();
-    const packCode = printTemplateJson._links.self.href.split("/").pop();
-
-    templates.push(packCode);
-  }
-
-  return templates;
+  return printTemplatesJson;
 };
 
 export const getSmsFulfilmentTemplates = async (surveyId) => {
-  const response = await fetch(`/api/surveys/${surveyId}/smsTemplates`);
+  const response = await fetch(`/api/fulfilmentSurveySmsTemplates/?surveyId=${surveyId}`);
   const smsFulfilmentTemplatesJson = await response.json();
-  const smsFulfilmentTemplates =
-    smsFulfilmentTemplatesJson._embedded.fulfilmentSurveySmsTemplates;
 
-  let templates = [];
-
-  for (const smsTemplate of smsFulfilmentTemplates) {
-    const smsFulfilmentTemplateUrl = new URL(
-      smsTemplate._links.smsTemplate.href
-    );
-
-    const smsFulfilmentTemplateResponse = await fetch(
-      smsFulfilmentTemplateUrl.pathname
-    );
-    const smsFulfilmentTemplateJson =
-      await smsFulfilmentTemplateResponse.json();
-    const packCode = smsFulfilmentTemplateJson._links.self.href
-      .split("/")
-      .pop();
-
-    templates.push(packCode);
-  }
-
-  return templates;
+  return smsFulfilmentTemplatesJson;
 };
 
 export const getActionRulePrintTemplates = async (surveyId) => {
   const response = await fetch(
-    `/api/surveys/${surveyId}/actionRulePrintTemplates`
+    `/api/actionRuleSurveyPrintTemplates/?surveyId=${surveyId}`
   );
   const printTemplatesJson = await response.json();
-  const printTemplates =
-    printTemplatesJson._embedded.actionRuleSurveyPrintTemplates;
 
-  let templates = [];
-
-  for (let i = 0; i < printTemplates.length; i++) {
-    const print_template_url = new URL(
-      printTemplates[i]._links.printTemplate.href
-    );
-
-    const printTemplateResponse = await fetch(print_template_url.pathname);
-    const printTemplateJson = await printTemplateResponse.json();
-    const packCode = printTemplateJson._links.self.href.split("/").pop();
-
-    templates.push(packCode);
-  }
-
-  return templates;
+  return printTemplatesJson;
 };
 
 export const getActionRuleSmsTemplates = async (surveyId) => {
   const response = await fetch(
-    `/api/surveys/${surveyId}/actionRuleSmsTemplates`
+    `/api/actionRuleSurveySmsTemplates/?surveyId=${surveyId}`
   );
   const smsTemplatesJson = await response.json();
-  const smsTemplates = smsTemplatesJson._embedded.actionRuleSurveySmsTemplates;
 
-  let templates = [];
-
-  for (let i = 0; i < smsTemplates.length; i++) {
-    const print_template_url = new URL(smsTemplates[i]._links.smsTemplate.href);
-
-    const smsTemplateResponse = await fetch(print_template_url.pathname);
-    const smsTemplateJson = await smsTemplateResponse.json();
-    const packCode = smsTemplateJson._links.self.href.split("/").pop();
-
-    templates.push(packCode);
-  }
-
-  return templates;
+  return smsTemplatesJson;
 };
 
 export const getSensitiveSampleColumns = async (surveyId) => {

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -2,28 +2,18 @@ export const getAllPrintTemplates = async () => {
   const response = await fetch("/api/printTemplates");
   const templateJson = await response.json();
 
-  let templates = [];
+  const templatePackCodes = templateJson.map(template => template.packCode)
 
-  for (let i = 0; i < templateJson._embedded.printTemplates.length; i++) {
-    const packCode = templateJson._embedded.printTemplates[i]._links.self.href
-      .split("/")
-      .pop();
-    templates.push(packCode);
-  }
-
-  return templates;
+  return templatePackCodes;
 };
+
 export const getAllSmsTemplates = async () => {
   const response = await fetch("/api/smsTemplates");
   const templateJson = await response.json();
 
-  let templates = [];
-  for (const smsTemplate of templateJson._embedded.smsTemplates) {
-    const packCode = smsTemplate._links.self.href.split("/").pop();
-    templates.push(packCode);
-  }
+  const templatePackCodes = templateJson.map(template => template.packCode)
 
-  return templates;
+  return templatePackCodes;
 };
 
 export const getFulfilmentPrintTemplates = async (surveyId) => {

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -2,7 +2,7 @@ export const getAllPrintTemplates = async () => {
   const response = await fetch("/api/printTemplates");
   const templateJson = await response.json();
 
-  const templatePackCodes = templateJson.map(template => template.packCode)
+  const templatePackCodes = templateJson.map((template) => template.packCode);
 
   return templatePackCodes;
 };
@@ -11,7 +11,7 @@ export const getAllSmsTemplates = async () => {
   const response = await fetch("/api/smsTemplates");
   const templateJson = await response.json();
 
-  const templatePackCodes = templateJson.map(template => template.packCode)
+  const templatePackCodes = templateJson.map((template) => template.packCode);
 
   return templatePackCodes;
 };
@@ -26,7 +26,9 @@ export const getFulfilmentPrintTemplates = async (surveyId) => {
 };
 
 export const getSmsFulfilmentTemplates = async (surveyId) => {
-  const response = await fetch(`/api/fulfilmentSurveySmsTemplates/?surveyId=${surveyId}`);
+  const response = await fetch(
+    `/api/fulfilmentSurveySmsTemplates/?surveyId=${surveyId}`
+  );
   const smsFulfilmentTemplatesJson = await response.json();
 
   return smsFulfilmentTemplatesJson;

--- a/ui/src/common.js
+++ b/ui/src/common.js
@@ -1,11 +1,3 @@
-export const uuidv4 = () => {
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-    var r = (Math.random() * 16) | 0,
-      v = c === "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-};
-
 export const convertStatusText = (status) => {
   if (status === "FILE_UPLOADED") {
     return "File Uploaded";


### PR DESCRIPTION
# Motivation and Context
The Spring "Data REST" auto-generated APIs are great for rapid application development, but the security features we need don't lend themselves readily to the pattern: we will end up exposing sensitive data, and creating a large attack surface, unless we are very careful.

# What has changed
Replaced all the Spring auto-generated APIs with handwritten ones, which have full security and only expose explicit data, which is allowed to be viewed to prevent accidental data breaches.

# How to test?
Every single feature of Support Tool has been affected, but there should be zero regression. Basically, do a full manual retest. Or, just trust me: I tested everything.

# Links
Trello: https://trello.com/c/qDr6CDkJ