### PR TITLE
Integration test [almost] all the endpoints

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyPrintTemplateEndpoint.java
@@ -60,7 +60,7 @@ public class ActionRuleSurveyPrintTemplateEndpoint {
     userIdentity.checkUserPermission(
         userEmail,
         survey,
-        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES);
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES);
 
     return actionRuleSurveyPrintTemplateRepository.findBySurvey(survey).stream()
         .map(arspt -> arspt.getPrintTemplate().getPackCode())

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/DeactivateUacEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/DeactivateUacEndpoint.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
 import static com.google.cloud.spring.pubsub.support.PubSubTopicUtils.toProjectTopicName;
-import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE;
+import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.DEACTIVATE_UAC;
 
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import java.util.Optional;
@@ -57,7 +57,7 @@ public class DeactivateUacEndpoint {
     userIdentity.checkUserPermission(
         userEmail,
         uacQidLinkOpt.get().getCaze().getCollectionExercise().getSurvey(),
-        CREATE_PRINT_TEMPLATE);
+        DEACTIVATE_UAC);
 
     EventDTO event = new EventDTO();
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintSuppliersEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/PrintSuppliersEndpoint.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
-import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE;
+import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.LIST_PRINT_SUPPLIERS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,7 +37,7 @@ public class PrintSuppliersEndpoint {
   @GetMapping
   public Set<String> getPrintSuppliers(
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    userIdentity.checkGlobalUserPermission(userEmail, CREATE_PRINT_TEMPLATE);
+    userIdentity.checkGlobalUserPermission(userEmail, LIST_PRINT_SUPPLIERS);
 
     if (printSuppliers != null) {
       return printSuppliers;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -51,7 +51,7 @@ public class SmsTemplateEndpoint {
       @RequestBody SmsTemplateDto smsTemplateDto,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     userIdentity.checkGlobalUserPermission(
-        userEmail, UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE);
+        userEmail, UserGroupAuthorisedActivityType.CREATE_SMS_TEMPLATE);
 
     SmsTemplate smsTemplate = new SmsTemplate();
     smsTemplate.setTemplate(smsTemplateDto.getTemplate());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserEndpoint.java
@@ -40,7 +40,7 @@ public class UserEndpoint {
         userRepository
             .findById(userId)
             .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
 
     return mapDto(user);
   }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -25,8 +25,8 @@ import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupMemberDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupPermissionDto;
 import uk.gov.ons.ssdc.supporttool.testhelper.IntegrationTestHelper;
 
-/* The purpose of these tests is to check, in a quick & dirty way, that they _work_ without being
- * too fussy. There are circa 140 endpoints which support the Support Tool UI, but it remains
+/* The purpose of these tests is to check, in a quick & dirty way, the endpoints _work_ without
+ * being too fussy. There are circa 140 endpoints which support the Support Tool UI, but it remains
  * a tool for developers and testers, so doesn't need to be tested to the same rigorous standards
  * as something which would be used by end-users... it would be too costly!
  *

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -36,7 +36,7 @@ import uk.gov.ons.ssdc.supporttool.testhelper.IntegrationTestHelper;
  * namely the one and only one which _should_ be allowed. Then we call it again, without that
  * permission and check that we get a 403 FORBIDDEN response.
  *
- * The reason why all these tests are in one file is performance: if they were in seperate files
+ * The reason why all these tests are in one file is performance: if they were in separate files
  * then Spring Boot would have to start and stop for every endpoint, which would take 30 seconds, so
  * for 26+ endpoints, that would take 13 minutes... unacceptably long for a build cycle.
  *

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -62,6 +62,57 @@ public class AllEndpointsIT {
 
     integrationTestHelper.testPost(
         port,
+        UserGroupAuthorisedActivityType.CREATE_PRINT_ACTION_RULE,
+        (bundle) -> "actionRules",
+        (bundle) -> {
+          ActionRuleDto actionRuleDto = new ActionRuleDto();
+          actionRuleDto.setType(ActionRuleType.PRINT);
+          actionRuleDto.setCollectionExerciseId(bundle.getCollexId());
+          actionRuleDto.setTriggerDateTime(OffsetDateTime.now());
+          actionRuleDto.setPackCode(bundle.getPrintTemplatePackCode());
+          return actionRuleDto;
+        });
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_SMS_ACTION_RULE,
+        (bundle) -> "actionRules",
+        (bundle) -> {
+          ActionRuleDto actionRuleDto = new ActionRuleDto();
+          actionRuleDto.setType(ActionRuleType.SMS);
+          actionRuleDto.setCollectionExerciseId(bundle.getCollexId());
+          actionRuleDto.setTriggerDateTime(OffsetDateTime.now());
+          actionRuleDto.setPackCode(bundle.getSmsTemplatePackCode());
+          actionRuleDto.setPhoneNumberColumn("testPhoneNumber");
+          return actionRuleDto;
+        });
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_OUTBOUND_PHONE_ACTION_RULE,
+        (bundle) -> "actionRules",
+        (bundle) -> {
+          ActionRuleDto actionRuleDto = new ActionRuleDto();
+          actionRuleDto.setType(ActionRuleType.OUTBOUND_TELEPHONE);
+          actionRuleDto.setCollectionExerciseId(bundle.getCollexId());
+          actionRuleDto.setTriggerDateTime(OffsetDateTime.now());
+          return actionRuleDto;
+        });
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_FACE_TO_FACE_ACTION_RULE,
+        (bundle) -> "actionRules",
+        (bundle) -> {
+          ActionRuleDto actionRuleDto = new ActionRuleDto();
+          actionRuleDto.setType(ActionRuleType.FACE_TO_FACE);
+          actionRuleDto.setCollectionExerciseId(bundle.getCollexId());
+          actionRuleDto.setTriggerDateTime(OffsetDateTime.now());
+          return actionRuleDto;
+        });
+
+    integrationTestHelper.testPost(
+        port,
         UserGroupAuthorisedActivityType.CREATE_DEACTIVATE_UAC_ACTION_RULE,
         (bundle) -> "actionRules",
         (bundle) -> {

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,7 +9,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.common.validation.Rule;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.ActionRuleDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.CollectionExerciseDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintTemplateDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsTemplateDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.SurveyDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupMemberDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupPermissionDto;
 import uk.gov.ons.ssdc.supporttool.testhelper.IntegrationTestHelper;
 
 @ExtendWith(SpringExtension.class)
@@ -19,10 +34,286 @@ public class AllEndpointsIT {
   @LocalServerPort private int port;
 
   @Test
-  public void testAllTheEndpoints() {
+  public void testActionRuleEndpoints() {
     integrationTestHelper.testGet(
         port,
         UserGroupAuthorisedActivityType.LIST_ACTION_RULES,
         (bundle) -> String.format("actionRules/?collectionExercise=%s", bundle.getCollexId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_DEACTIVATE_UAC_ACTION_RULE,
+        (bundle) -> "actionRules",
+        (bundle) -> {
+          ActionRuleDto actionRuleDto = new ActionRuleDto();
+          actionRuleDto.setType(ActionRuleType.DEACTIVATE_UAC);
+          actionRuleDto.setCollectionExerciseId(bundle.getCollexId());
+          actionRuleDto.setTriggerDateTime(OffsetDateTime.now());
+          return actionRuleDto;
+        });
+  }
+
+  @Test
+  public void testActionRuleSurveyPrintTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES,
+        (bundle) ->
+            String.format("actionRuleSurveyPrintTemplates/?surveyId=%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.ALLOW_PRINT_TEMPLATE_ON_ACTION_RULE,
+        (bundle) -> "actionRuleSurveyPrintTemplates",
+        (bundle) -> {
+          AllowTemplateOnSurvey allowTemplateOnSurvey = new AllowTemplateOnSurvey();
+          allowTemplateOnSurvey.setSurveyId(bundle.getSurveyId());
+          allowTemplateOnSurvey.setPackCode(bundle.getPrintTemplatePackCode());
+          return allowTemplateOnSurvey;
+        });
+  }
+
+  @Test
+  public void testActionRuleSurveySmsTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES,
+        (bundle) ->
+            String.format("actionRuleSurveySmsTemplates/?surveyId=%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.ALLOW_SMS_TEMPLATE_ON_ACTION_RULE,
+        (bundle) -> "actionRuleSurveySmsTemplates",
+        (bundle) -> {
+          AllowTemplateOnSurvey allowTemplateOnSurvey = new AllowTemplateOnSurvey();
+          allowTemplateOnSurvey.setSurveyId(bundle.getSurveyId());
+          allowTemplateOnSurvey.setPackCode(bundle.getSmsTemplatePackCode());
+          return allowTemplateOnSurvey;
+        });
+  }
+
+  @Test
+  public void testCaseEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.VIEW_CASE_DETAILS,
+        (bundle) -> String.format("cases/%s", bundle.getCaseId()));
+  }
+
+  @Test
+  public void testCollectionExerciseEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.VIEW_COLLECTION_EXERCISE,
+        (bundle) -> String.format("collectionExercises/%s", bundle.getCollexId()));
+
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_COLLECTION_EXERCISES,
+        (bundle) -> String.format("collectionExercises/?surveyId=%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_COLLECTION_EXERCISE,
+        (bundle) -> "collectionExercises",
+        (bundle) -> {
+          CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+          collectionExerciseDto.setSurveyId(bundle.getSurveyId());
+          collectionExerciseDto.setName("Test");
+          return collectionExerciseDto;
+        });
+  }
+
+  @Test
+  public void testDeactivateUacEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.DEACTIVATE_UAC,
+        (bundle) -> String.format("deactivateUac/%s", bundle.getQid()));
+  }
+
+  @Test
+  public void testFulfilmentSurveyPrintTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS,
+        (bundle) ->
+            String.format("fulfilmentSurveyPrintTemplates/?surveyId=%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.ALLOW_PRINT_TEMPLATE_ON_FULFILMENT,
+        (bundle) -> "fulfilmentSurveyPrintTemplates",
+        (bundle) -> {
+          AllowTemplateOnSurvey allowTemplateOnSurvey = new AllowTemplateOnSurvey();
+          allowTemplateOnSurvey.setSurveyId(bundle.getSurveyId());
+          allowTemplateOnSurvey.setPackCode(bundle.getPrintTemplatePackCode());
+          return allowTemplateOnSurvey;
+        });
+  }
+
+  @Test
+  public void testFulfilmentSurveySmsTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS,
+        (bundle) ->
+            String.format("fulfilmentSurveySmsTemplates/?surveyId=%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.ALLOW_SMS_TEMPLATE_ON_FULFILMENT,
+        (bundle) -> "fulfilmentSurveySmsTemplates",
+        (bundle) -> {
+          AllowTemplateOnSurvey allowTemplateOnSurvey = new AllowTemplateOnSurvey();
+          allowTemplateOnSurvey.setSurveyId(bundle.getSurveyId());
+          allowTemplateOnSurvey.setPackCode(bundle.getSmsTemplatePackCode());
+          return allowTemplateOnSurvey;
+        });
+  }
+
+  @Test
+  public void testPrintSuppliersEndpoints() {
+    integrationTestHelper.testGet(
+        port, UserGroupAuthorisedActivityType.LIST_PRINT_SUPPLIERS, (bundle) -> "printsuppliers");
+  }
+
+  @Test
+  public void testPrintTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port, UserGroupAuthorisedActivityType.LIST_PRINT_TEMPLATES, (bundle) -> "printTemplates");
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_PRINT_TEMPLATE,
+        (bundle) -> "printTemplates",
+        (bundle) -> {
+          PrintTemplateDto printTemplateDto = new PrintTemplateDto();
+          printTemplateDto.setTemplate(new String[] {"foo"});
+          printTemplateDto.setPrintSupplier("SUPPLIER_A");
+          printTemplateDto.setPackCode("TEST_" + UUID.randomUUID());
+          return printTemplateDto;
+        });
+  }
+
+  @Test
+  public void testSmsTemplateEndpoints() {
+    integrationTestHelper.testGet(
+        port, UserGroupAuthorisedActivityType.LIST_SMS_TEMPLATES, (bundle) -> "smsTemplates");
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_SMS_TEMPLATE,
+        (bundle) -> "smsTemplates",
+        (bundle) -> {
+          SmsTemplateDto smsTemplateDto = new SmsTemplateDto();
+          smsTemplateDto.setTemplate(new String[] {"foo"});
+          smsTemplateDto.setNotifyTemplateId(UUID.randomUUID());
+          smsTemplateDto.setPackCode("TEST_" + UUID.randomUUID());
+          return smsTemplateDto;
+        });
+  }
+
+  @Test
+  public void testSurveyEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.VIEW_SURVEY,
+        (bundle) -> String.format("surveys/%s", bundle.getSurveyId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.CREATE_SURVEY,
+        (bundle) -> "surveys",
+        (bundle) -> {
+          SurveyDto surveyDto = new SurveyDto();
+          surveyDto.setName("Test");
+          surveyDto.setSampleSeparator(',');
+          surveyDto.setSampleValidationRules(
+              new ColumnValidator[] {new ColumnValidator("foo", false, new Rule[] {})});
+          return surveyDto;
+        });
+  }
+
+  @Test
+  public void testUserEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("users/%s", bundle.getUserId()));
+
+    integrationTestHelper.testGet(
+        port, UserGroupAuthorisedActivityType.SUPER_USER, (bundle) -> "users");
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> "users",
+        (bundle) -> {
+          UserDto userDto = new UserDto();
+          userDto.setEmail("TEST_EMAIL_" + UUID.randomUUID());
+          return userDto;
+        });
+  }
+
+  @Test
+  public void testUserGroupEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroups/%s", bundle.getGroupId()));
+
+    integrationTestHelper.testGet(
+        port, UserGroupAuthorisedActivityType.SUPER_USER, (bundle) -> "userGroups");
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> "userGroups",
+        (bundle) -> {
+          UserGroupDto userGroupDto = new UserGroupDto();
+          userGroupDto.setName("Test");
+          return userGroupDto;
+        });
+  }
+
+  @Test
+  public void testUserGroupMemberEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroupMembers/?userId=%s", bundle.getUserId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> "userGroupMembers",
+        (bundle) -> {
+          UserGroupMemberDto userGroupMemberDto = new UserGroupMemberDto();
+          userGroupMemberDto.setUserId(bundle.getUserId());
+          userGroupMemberDto.setGroupId(bundle.getGroupId());
+          return userGroupMemberDto;
+        });
+  }
+
+  @Test
+  public void testUserGroupPermissionEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroupPermissions/?groupId=%s", bundle.getGroupId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> "userGroupPermissions",
+        (bundle) -> {
+          UserGroupPermissionDto groupPermissionDto = new UserGroupPermissionDto();
+          groupPermissionDto.setGroupId(bundle.getGroupId());
+          groupPermissionDto.setSurveyId(bundle.getSurveyId());
+          groupPermissionDto.setAuthorisedActivity(UserGroupAuthorisedActivityType.LOAD_SAMPLE);
+          return groupPermissionDto;
+        });
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
@@ -13,4 +13,6 @@ public class BundleOfUsefulTestStuff {
   private String smsTemplatePackCode;
   private UUID userId;
   private UUID groupId;
+  private UUID groupMemberId;
+  private UUID groupPermissionId;
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
@@ -7,4 +7,10 @@ import lombok.Data;
 public class BundleOfUsefulTestStuff {
   private UUID surveyId;
   private UUID collexId;
+  private UUID caseId;
+  private String qid;
+  private String printTemplatePackCode;
+  private String smsTemplatePackCode;
+  private UUID userId;
+  private UUID groupId;
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundlePostObjectGetter.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundlePostObjectGetter.java
@@ -1,0 +1,6 @@
+package uk.gov.ons.ssdc.supporttool.testhelper;
+
+@FunctionalInterface
+public interface BundlePostObjectGetter {
+  Object getObject(BundleOfUsefulTestStuff bundle);
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleUrlGetter.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleUrlGetter.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.testhelper;
 
 @FunctionalInterface
-public interface BundleFunction {
+public interface BundleUrlGetter {
   String getUrl(BundleOfUsefulTestStuff bundle);
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -145,7 +145,8 @@ public class IntegrationTestHelper {
     survey.setSampleValidationRules(
         new ColumnValidator[] {
           new ColumnValidator("foo", false, new Rule[] {}),
-          new ColumnValidator("bar", false, new Rule[] {})
+          new ColumnValidator("bar", false, new Rule[] {}),
+          new ColumnValidator("testPhoneNumber", true, new Rule[] {})
         });
     survey.setSampleSeparator(',');
     survey = surveyRepository.saveAndFlush(survey);

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -81,7 +81,7 @@ public class IntegrationTestHelper {
 
     String url = String.format("http://localhost:%d/api/%s", port, bundleUrlGetter.getUrl(bundle));
     ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-    assertThat(response.getStatusCodeValue()).isBetween(200, 299);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
     deleteAllPermissions();
     restoreDummyUserAndOtherGubbins(bundle); // Restore the user etc so that user tests still work
@@ -105,7 +105,7 @@ public class IntegrationTestHelper {
     String url = String.format("http://localhost:%d/api/%s", port, bundleUrlGetter.getUrl(bundle));
     Object objectToPost = bundlePostObjectGetter.getObject(bundle);
     ResponseEntity<String> response = restTemplate.postForEntity(url, objectToPost, String.class);
-    assertThat(response.getStatusCodeValue()).isBetween(200, 299);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     deleteAllPermissions();
     restoreDummyUserAndOtherGubbins(bundle); // Restore the user etc so that user tests still work

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -81,16 +81,18 @@ public class IntegrationTestHelper {
 
     String url = String.format("http://localhost:%d/api/%s", port, bundleUrlGetter.getUrl(bundle));
     ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getStatusCode()).as("GET is OK").isEqualTo(HttpStatus.OK);
 
     deleteAllPermissions();
     restoreDummyUserAndOtherGubbins(bundle); // Restore the user etc so that user tests still work
 
     try {
       restTemplate.getForEntity(url, String.class);
-      fail("API call was not forbidden, but should have been");
+      fail("GET API call was not forbidden, but should have been");
     } catch (HttpClientErrorException expectedException) {
-      assertThat(expectedException.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+      assertThat(expectedException.getStatusCode())
+          .as("GET is FORBIDDEN")
+          .isEqualTo(HttpStatus.FORBIDDEN);
     }
   }
 
@@ -105,16 +107,18 @@ public class IntegrationTestHelper {
     String url = String.format("http://localhost:%d/api/%s", port, bundleUrlGetter.getUrl(bundle));
     Object objectToPost = bundlePostObjectGetter.getObject(bundle);
     ResponseEntity<String> response = restTemplate.postForEntity(url, objectToPost, String.class);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getStatusCode()).as("POST is CREATED").isEqualTo(HttpStatus.CREATED);
 
     deleteAllPermissions();
     restoreDummyUserAndOtherGubbins(bundle); // Restore the user etc so that user tests still work
 
     try {
       restTemplate.postForEntity(url, objectToPost, String.class);
-      fail("API call was not forbidden, but should have been");
+      fail("POST API call was not forbidden, but should have been");
     } catch (HttpClientErrorException expectedException) {
-      assertThat(expectedException.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+      assertThat(expectedException.getStatusCode())
+          .as("POST is FORBIDDEN")
+          .isEqualTo(HttpStatus.FORBIDDEN);
     }
   }
 
@@ -131,9 +135,11 @@ public class IntegrationTestHelper {
 
     try {
       restTemplate.delete(url);
-      fail("API call was not forbidden, but should have been");
+      fail("DELETE API call was not forbidden, but should have been");
     } catch (HttpClientErrorException expectedException) {
-      assertThat(expectedException.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+      assertThat(expectedException.getStatusCode())
+          .as("DELETE is FORBIDDEN")
+          .isEqualTo(HttpStatus.FORBIDDEN);
     }
   }
 


### PR DESCRIPTION
# Motivation and Context
There are almost 70 RESTful API endpoints which are required for the Support Tool to work. We should test them... at least to check that the security is working for all of them.

# What has changed
Built a mechanism to check that all the endpoints are protected by role-based access control (RBAC) and then used that to check almost all the endpoints.

# How to test?
Build the project... it will automatically test all the endpoints.

# Links
Trello: https://trello.com/c/3us6jDjj