### PR TITLE
Add Gov Notify Template ID to UI

### DIFF
--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -475,6 +475,9 @@ class LandingPage extends Component {
         <TableCell component="th" scope="row">
           {JSON.stringify(smsTemplate.template)}
         </TableCell>
+        <TableCell component="th" scope="row">
+          {smsTemplate.notifyTemplateId}
+        </TableCell>
       </TableRow>
     ));
 
@@ -543,6 +546,7 @@ class LandingPage extends Component {
                 <TableRow>
                   <TableCell>Pack Code</TableCell>
                   <TableCell>Template</TableCell>
+                  <TableCell>Gov Notify Template ID</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>{smsTemplateRows}</TableBody>


### PR DESCRIPTION
# Motivation and Context
It's useful to know which template an SMS template is using, at the Gov Notify end of business.

# What has changed
Displayed the ID in the UI.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/gdpVHBKS

# Screenshots (if appropriate):
<img width="732" alt="Screenshot 2021-10-01 at 11 44 49" src="https://user-images.githubusercontent.com/41681172/135607472-7cc575d1-ed20-4fbd-a8ed-3213a06d19bc.png">
