### PR TITLE
Don't call APIs if not authorised to do so

### DIFF
--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -33,18 +33,26 @@ class CaseDetails extends Component {
   };
 
   componentDidMount() {
-    this.getSurveyName(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getCasesAndQidData();
-
-    this.interval = setInterval(() => this.getCasesAndQidData(), 1000);
+    this.getAuthorisedBackendData();
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  getSurveyName = async () => {
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+
+    this.getSurveyName(authorisedActivities); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getCasesAndQidData(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.getCasesAndQidData(authorisedActivities),
+      1000
+    );
+  };
+
+  getSurveyName = async (authorisedActivities) => {
     const response = await fetch(`/api/surveys/${this.props.surveyId}`);
 
     const surveyJson = await response.json();
@@ -63,9 +71,11 @@ class CaseDetails extends Component {
     const authJson = await response.json();
 
     this.setState({ authorisedActivities: authJson });
+
+    return authJson;
   };
 
-  getCasesAndQidData = async () => {
+  getCasesAndQidData = async (authorisedActivities) => {
     const response = await fetch(`/api/cases/${this.props.caseId}`);
     const caseJson = await response.json();
 

--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -53,6 +53,8 @@ class CaseDetails extends Component {
   };
 
   getSurveyName = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_SURVEY")) return;
+
     const response = await fetch(`/api/surveys/${this.props.surveyId}`);
 
     const surveyJson = await response.json();
@@ -76,6 +78,8 @@ class CaseDetails extends Component {
   };
 
   getCasesAndQidData = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_CASE_DETAILS")) return;
+
     const response = await fetch(`/api/cases/${this.props.caseId}`);
     const caseJson = await response.json();
 

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -47,19 +47,26 @@ class CollectionExerciseDetails extends Component {
   };
 
   componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getCollectionExerciseName();
-    this.getActionRules();
-    this.getPrintTemplates();
-    this.getSmsTemplates();
-    this.getSensitiveSampleColumns();
-
-    this.interval = setInterval(() => this.getActionRules(), 1000);
+    this.getAuthorisedBackendData();
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
+
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getCollectionExerciseName(authorisedActivities);
+    this.getActionRules(authorisedActivities);
+    this.getPrintTemplates(authorisedActivities);
+    this.getSmsTemplates(authorisedActivities);
+    this.getSensitiveSampleColumns(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.getActionRules(authorisedActivities),
+      1000
+    );
+  };
 
   getAuthorisedActivities = async () => {
     const response = await fetch(`/api/auth?surveyId=${this.props.surveyId}`);
@@ -72,16 +79,19 @@ class CollectionExerciseDetails extends Component {
     const authJson = await response.json();
 
     this.setState({ authorisedActivities: authJson });
+
+    return authJson;
   };
 
-  getSensitiveSampleColumns = async () => {
+  getSensitiveSampleColumns = async (authorisedActivities) => {
     const sensitiveSampleColumns = await getSensitiveSampleColumns(
+      authorisedActivities,
       this.props.surveyId
     );
     this.setState({ sensitiveSampleColumns: sensitiveSampleColumns });
   };
 
-  getCollectionExerciseName = async () => {
+  getCollectionExerciseName = async (authorisedActivities) => {
     const response = await fetch(
       `api/collectionExercises/${this.props.collectionExerciseId}`
     );
@@ -96,7 +106,7 @@ class CollectionExerciseDetails extends Component {
     this.setState({ collectionExerciseName: collectionExerciseJson.name });
   };
 
-  getActionRules = async () => {
+  getActionRules = async (authorisedActivities) => {
     const response = await fetch(
       `/api/actionRules/?collectionExercise=${this.props.collectionExerciseId}`
     );
@@ -107,13 +117,19 @@ class CollectionExerciseDetails extends Component {
     });
   };
 
-  getPrintTemplates = async () => {
-    const packCodes = await getActionRulePrintTemplates(this.props.surveyId);
+  getPrintTemplates = async (authorisedActivities) => {
+    const packCodes = await getActionRulePrintTemplates(
+      authorisedActivities,
+      this.props.surveyId
+    );
     this.setState({ printPackCodes: packCodes });
   };
 
-  getSmsTemplates = async () => {
-    const packCodes = await getActionRuleSmsTemplates(this.props.surveyId);
+  getSmsTemplates = async (authorisedActivities) => {
+    const packCodes = await getActionRuleSmsTemplates(
+      authorisedActivities,
+      this.props.surveyId
+    );
     this.setState({ smsPackCodes: packCodes });
   };
 

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -92,6 +92,8 @@ class CollectionExerciseDetails extends Component {
   };
 
   getCollectionExerciseName = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_COLLECTION_EXERCISE")) return;
+
     const response = await fetch(
       `api/collectionExercises/${this.props.collectionExerciseId}`
     );
@@ -107,6 +109,8 @@ class CollectionExerciseDetails extends Component {
   };
 
   getActionRules = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_ACTION_RULES")) return;
+
     const response = await fetch(
       `/api/actionRules/?collectionExercise=${this.props.collectionExerciseId}`
     );
@@ -118,6 +122,8 @@ class CollectionExerciseDetails extends Component {
   };
 
   getPrintTemplates = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_PRINT_TEMPLATES")) return;
+
     const packCodes = await getActionRulePrintTemplates(
       authorisedActivities,
       this.props.surveyId
@@ -126,6 +132,8 @@ class CollectionExerciseDetails extends Component {
   };
 
   getSmsTemplates = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_SMS_TEMPLATES")) return;
+
     const packCodes = await getActionRuleSmsTemplates(
       authorisedActivities,
       this.props.surveyId

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -122,7 +122,12 @@ class CollectionExerciseDetails extends Component {
   };
 
   getPrintTemplates = async (authorisedActivities) => {
-    if (!authorisedActivities.includes("LIST_PRINT_TEMPLATES")) return;
+    if (
+      !authorisedActivities.includes(
+        "LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES"
+      )
+    )
+      return;
 
     const packCodes = await getActionRulePrintTemplates(
       authorisedActivities,
@@ -132,7 +137,12 @@ class CollectionExerciseDetails extends Component {
   };
 
   getSmsTemplates = async (authorisedActivities) => {
-    if (!authorisedActivities.includes("LIST_SMS_TEMPLATES")) return;
+    if (
+      !authorisedActivities.includes(
+        "LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES"
+      )
+    )
+      return;
 
     const packCodes = await getActionRuleSmsTemplates(
       authorisedActivities,

--- a/ui/src/ExceptionManager.js
+++ b/ui/src/ExceptionManager.js
@@ -41,6 +41,8 @@ class ExceptionManager extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const response = await fetch("/api/exceptionManager/badMessagesSummary");
     const exceptions = await response.json();
 

--- a/ui/src/ExceptionManager.js
+++ b/ui/src/ExceptionManager.js
@@ -24,18 +24,23 @@ class ExceptionManager extends Component {
     peekResult: "",
   };
 
-  componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.refreshDataFromBackend();
-
-    this.interval = setInterval(() => this.refreshDataFromBackend(), 1000);
-  }
+  componentDidMount() {}
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  refreshDataFromBackend = async () => {
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.refreshDataFromBackend(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.refreshDataFromBackend(authorisedActivities),
+      1000
+    );
+  };
+
+  refreshDataFromBackend = async (authorisedActivities) => {
     const response = await fetch("/api/exceptionManager/badMessagesSummary");
     const exceptions = await response.json();
 
@@ -55,6 +60,8 @@ class ExceptionManager extends Component {
       authorisedActivities: authorisedActivities,
       isLoading: false,
     });
+
+    return authorisedActivities;
   };
 
   openDetailsDialog = async (messageHash) => {

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -39,20 +39,27 @@ class GroupDetails extends Component {
   };
 
   componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getGroup();
-    this.getAllActivities();
-    this.getAllSurveys();
-    this.getUserGroupPermissions();
-
-    this.interval = setInterval(() => this.getUserGroupPermissions(), 1000);
+    this.getAuthorisedBackendData();
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  getGroup = async () => {
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getGroup(authorisedActivities);
+    this.getAllActivities(authorisedActivities);
+    this.getAllSurveys(authorisedActivities);
+    this.getUserGroupPermissions(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.getUserGroupPermissions(authorisedActivities),
+      1000
+    );
+  };
+
+  getGroup = async (authorisedActivities) => {
     const groupResponse = await fetch(`/api/userGroups/${this.props.groupId}`);
 
     const groupJson = await groupResponse.json();
@@ -62,7 +69,7 @@ class GroupDetails extends Component {
     });
   };
 
-  getUserGroupPermissions = async () => {
+  getUserGroupPermissions = async (authorisedActivities) => {
     const permissionsResponse = await fetch(
       `/api/userGroupPermissions/?groupId=${this.props.groupId}`
     );
@@ -87,9 +94,11 @@ class GroupDetails extends Component {
       authorisedActivities: authorisedActivities,
       isLoading: false,
     });
+
+    return authorisedActivities;
   };
 
-  getAllActivities = async () => {
+  getAllActivities = async (authorisedActivities) => {
     const activitiesResponse = await fetch("/api/authorisedActivityTypes");
     const activitiesJson = await activitiesResponse.json();
 
@@ -98,7 +107,7 @@ class GroupDetails extends Component {
     });
   };
 
-  getAllSurveys = async () => {
+  getAllSurveys = async (authorisedActivities) => {
     const surveysResponse = await fetch("/api/surveys");
     const surveysJson = await surveysResponse.json();
 

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -49,7 +49,7 @@ class GroupDetails extends Component {
   getAuthorisedBackendData = async () => {
     const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     this.getGroup(authorisedActivities);
-    this.getAllActivities(authorisedActivities);
+    this.getAllActivities();
     this.getAllSurveys(authorisedActivities);
     this.getUserGroupPermissions(authorisedActivities);
 
@@ -60,6 +60,8 @@ class GroupDetails extends Component {
   };
 
   getGroup = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const groupResponse = await fetch(`/api/userGroups/${this.props.groupId}`);
 
     const groupJson = await groupResponse.json();
@@ -70,6 +72,8 @@ class GroupDetails extends Component {
   };
 
   getUserGroupPermissions = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const permissionsResponse = await fetch(
       `/api/userGroupPermissions/?groupId=${this.props.groupId}`
     );
@@ -98,7 +102,8 @@ class GroupDetails extends Component {
     return authorisedActivities;
   };
 
-  getAllActivities = async (authorisedActivities) => {
+  getAllActivities = async () => {
+    // This is not an RBAC protected endpoint
     const activitiesResponse = await fetch("/api/authorisedActivityTypes");
     const activitiesJson = await activitiesResponse.json();
 
@@ -108,6 +113,8 @@ class GroupDetails extends Component {
   };
 
   getAllSurveys = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_SURVEYS")) return;
+
     const surveysResponse = await fetch("/api/surveys");
     const surveysJson = await surveysResponse.json();
 

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -170,7 +170,7 @@ class LandingPage extends Component {
   };
 
   openFulfilmentTriggerDialog = () => {
-    this.getFulfilmentTrigger(); // TODO - this is so ugly, but will have to live with it as I can't fix everything
+    this.getFulfilmentTrigger();
     this.setState({
       configureNextTriggerDisplayed: true,
     });

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -116,6 +116,11 @@ class LandingPage extends Component {
   };
 
   getFulfilmentTrigger = async () => {
+    if (
+      !this.state.authorisedActivities.includes("CONFIGURE_FULFILMENT_TRIGGER")
+    )
+      return;
+
     const response = await fetch(`/api/fulfilmentNextTriggers`);
 
     if (!response.ok) {
@@ -165,7 +170,7 @@ class LandingPage extends Component {
   };
 
   openFulfilmentTriggerDialog = () => {
-    this.getFulfilmentTrigger();
+    this.getFulfilmentTrigger(); // TODO - this is so ugly, but will have to live with it as I can't fix everything
     this.setState({
       configureNextTriggerDisplayed: true,
     });

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -59,11 +59,15 @@ class LandingPage extends Component {
 
   getAuthorisedBackendData = async () => {
     const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.refreshDataFromBackend(authorisedActivities);
     this.getPrintSuppliers(authorisedActivities); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
 
-    this.interval = setInterval(() => this.refreshDataFromBackend(this.state.authorisedActivities), 1000);
-  }
+    this.refreshDataFromBackend(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.refreshDataFromBackend(authorisedActivities),
+      1000
+    );
+  };
 
   getAuthorisedActivities = async () => {
     const authResponse = await fetch("/api/auth");
@@ -95,7 +99,7 @@ class LandingPage extends Component {
     this.setState({
       printSuppliers: supplierJson,
     });
-}
+  };
 
   getSurveys = async (authorisedActivities) => {
     if (!authorisedActivities.includes("LIST_SURVEYS")) return;

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -91,6 +91,13 @@ class PrintFulfilment extends Component {
 
   // TODO: Need to handle errors from Promises
   refreshDataFromBackend = async (authorisedActivities) => {
+    if (
+      !authorisedActivities.includes(
+        "LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS"
+      )
+    )
+      return;
+
     const fulfilmentPrintTemplates = await getFulfilmentPrintTemplates(
       authorisedActivities,
       this.props.surveyId

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -19,8 +19,31 @@ class PrintFulfilment extends Component {
     showDialog: false,
   };
 
+  componentDidMount() {
+    this.getAuthorisedBackendData();
+  }
+
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.refreshDataFromBackend(authorisedActivities);
+  };
+
+  getAuthorisedActivities = async () => {
+    const response = await fetch(`/api/auth?surveyId=${this.props.surveyId}`);
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const authJson = await response.json();
+
+    this.setState({ authorisedActivities: authJson });
+
+    return authJson;
+  };
+
   openDialog = () => {
-    this.refreshDataFromBackend();
     this.setState({
       showDialog: true,
     });
@@ -67,8 +90,9 @@ class PrintFulfilment extends Component {
   };
 
   // TODO: Need to handle errors from Promises
-  refreshDataFromBackend = async () => {
+  refreshDataFromBackend = async (authorisedActivities) => {
     const fulfilmentPrintTemplates = await getFulfilmentPrintTemplates(
+      authorisedActivities,
       this.props.surveyId
     );
 

--- a/ui/src/SensitiveData.js
+++ b/ui/src/SensitiveData.js
@@ -47,6 +47,8 @@ class SensitiveData extends Component {
   };
 
   getSensitiveSampleColumns = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_SURVEY")) return;
+
     const sensitiveColumns = await getSensitiveSampleColumns(
       authorisedActivities,
       this.props.surveyId

--- a/ui/src/SensitiveData.js
+++ b/ui/src/SensitiveData.js
@@ -22,12 +22,43 @@ class SensitiveData extends Component {
     validationError: false,
   };
 
+  componentDidMount() {
+    this.getAuthorisedBackendData();
+  }
+
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getSensitiveSampleColumns(authorisedActivities, this.props.surveyId);
+  };
+
+  getAuthorisedActivities = async () => {
+    const response = await fetch(`/api/auth?surveyId=${this.props.surveyId}`);
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const authJson = await response.json();
+
+    this.setState({ authorisedActivities: authJson });
+
+    return authJson;
+  };
+
+  getSensitiveSampleColumns = async (authorisedActivities) => {
+    const sensitiveColumns = await getSensitiveSampleColumns(
+      authorisedActivities,
+      this.props.surveyId
+    );
+    this.setState({
+      allowableSensitiveDataColumns: sensitiveColumns,
+    });
+  };
+
   openDialog = () => {
-    getSensitiveSampleColumns(this.props.surveyId).then((sensitiveColumns) => {
-      this.setState({
-        allowableSensitiveDataColumns: sensitiveColumns,
-        showDialog: true,
-      });
+    this.setState({
+      showDialog: true,
     });
   };
 

--- a/ui/src/SmsFulfilment.js
+++ b/ui/src/SmsFulfilment.js
@@ -72,6 +72,13 @@ class SmsFulfilment extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
+    if (
+      !authorisedActivities.includes(
+        "LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS"
+      )
+    )
+      return;
+
     const fulfilmentPrintTemplates = await getSmsFulfilmentTemplates(
       authorisedActivities,
       this.props.surveyId

--- a/ui/src/SmsFulfilment.js
+++ b/ui/src/SmsFulfilment.js
@@ -23,8 +23,31 @@ class SmsFulfilment extends Component {
     validationError: false,
   };
 
+  componentDidMount() {
+    this.getAuthorisedBackendData();
+  }
+
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.refreshDataFromBackend(authorisedActivities);
+  };
+
+  getAuthorisedActivities = async () => {
+    const response = await fetch(`/api/auth?surveyId=${this.props.surveyId}`);
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const authJson = await response.json();
+
+    this.setState({ authorisedActivities: authJson });
+
+    return authJson;
+  };
+
   openDialog = () => {
-    this.refreshDataFromBackend();
     this.setState({
       showDialog: true,
     });
@@ -47,8 +70,10 @@ class SmsFulfilment extends Component {
       phoneNumber: event.target.value,
     });
   };
-  refreshDataFromBackend = async () => {
+
+  refreshDataFromBackend = async (authorisedActivities) => {
     const fulfilmentPrintTemplates = await getSmsFulfilmentTemplates(
+      authorisedActivities,
       this.props.surveyId
     );
 
@@ -56,6 +81,7 @@ class SmsFulfilment extends Component {
       allowableSmsFulfilmentTemplates: fulfilmentPrintTemplates,
     });
   };
+
   onSmsTemplateChange = (event) => {
     this.setState({ packCode: event.target.value });
   };

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -49,6 +49,8 @@ class SurveyCaseSearch extends Component {
   };
 
   getCollectionExercises = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_COLLECTION_EXERCISES")) return;
+
     const response = await fetch(
       `/api/collectionExercises/?surveyId=${this.props.surveyId}`
     );
@@ -93,6 +95,8 @@ class SurveyCaseSearch extends Component {
   };
 
   getSampleColumns = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_SURVEY")) return;
+
     const response = await fetch(`/api/surveys/${this.props.surveyId}`);
     if (!response.ok) {
       return;

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -24,10 +24,14 @@ class SurveyCaseSearch extends Component {
   };
 
   componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getSampleColumns();
-    this.getCollectionExercises();
+    this.getAuthorisedBackendData();
   }
+
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getSampleColumns(authorisedActivities);
+    this.getCollectionExercises(authorisedActivities);
+  };
 
   getAuthorisedActivities = async () => {
     const response = await fetch(`/api/auth?surveyId=${this.props.surveyId}`);
@@ -40,9 +44,11 @@ class SurveyCaseSearch extends Component {
     const authJson = await response.json();
 
     this.setState({ authorisedActivities: authJson });
+
+    return authJson;
   };
 
-  getCollectionExercises = async () => {
+  getCollectionExercises = async (authorisedActivities) => {
     const response = await fetch(
       `/api/collectionExercises/?surveyId=${this.props.surveyId}`
     );
@@ -86,7 +92,7 @@ class SurveyCaseSearch extends Component {
     return /^\+?\d+$/.test(str);
   };
 
-  getSampleColumns = async () => {
+  getSampleColumns = async (authorisedActivities) => {
     const response = await fetch(`/api/surveys/${this.props.surveyId}`);
     if (!response.ok) {
       return;

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -90,7 +90,9 @@ class SurveyDetails extends Component {
     return authJson;
   };
 
-  getSurveyName = async () => {
+  getSurveyName = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("VIEW_SURVEY")) return;
+
     const response = await fetch(`/api/surveys/${this.props.surveyId}`);
 
     const surveyJson = await response.json();
@@ -100,6 +102,8 @@ class SurveyDetails extends Component {
 
   refreshDataFromBackend = async (authorisedActivities) => {
     this.getCollectionExercises(authorisedActivities);
+
+    // TODO: The security of this is a nightmare, because the method assumes the user has a ton of permissions. Will work for now, but refactor in future.
 
     const allPrintFulfilmentTemplates = await getAllPrintTemplates(
       authorisedActivities
@@ -163,6 +167,8 @@ class SurveyDetails extends Component {
   };
 
   getCollectionExercises = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("LIST_COLLECTION_EXERCISES")) return;
+
     const response = await fetch(
       `/api/collectionExercises/?surveyId=${this.props.surveyId}`
     );

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -31,6 +31,7 @@ class SurveySampleSearch extends Component {
   }
 
   getRefusalTypes = async () => {
+    // This endpoint has no security
     const response = await fetch("/api/refusals/types");
     let refusalJson = await response.json();
 

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -53,6 +53,8 @@ class UserAdmin extends Component {
   };
 
   getUsers = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const usersResponse = await fetch("/api/users");
 
     const usersJson = await usersResponse.json();
@@ -63,6 +65,8 @@ class UserAdmin extends Component {
   };
 
   getGroups = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const groupsResponse = await fetch("/api/userGroups");
 
     const groupsJson = await groupsResponse.json();

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -30,22 +30,29 @@ class UserAdmin extends Component {
   };
 
   componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.refreshDataFromBackend();
-
-    this.interval = setInterval(() => this.refreshDataFromBackend(), 1000);
+    this.getAuthorisedBackendData();
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  refreshDataFromBackend = () => {
-    this.getUsers();
-    this.getGroups();
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.refreshDataFromBackend(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.refreshDataFromBackend(authorisedActivities),
+      1000
+    );
   };
 
-  getUsers = async () => {
+  refreshDataFromBackend = (authorisedActivities) => {
+    this.getUsers(authorisedActivities);
+    this.getGroups(authorisedActivities);
+  };
+
+  getUsers = async (authorisedActivities) => {
     const usersResponse = await fetch("/api/users");
 
     const usersJson = await usersResponse.json();
@@ -55,7 +62,7 @@ class UserAdmin extends Component {
     });
   };
 
-  getGroups = async () => {
+  getGroups = async (authorisedActivities) => {
     const groupsResponse = await fetch("/api/userGroups");
 
     const groupsJson = await groupsResponse.json();
@@ -78,6 +85,8 @@ class UserAdmin extends Component {
       authorisedActivities: authorisedActivities,
       isLoading: false,
     });
+
+    return authorisedActivities;
   };
 
   openCreateUserDialog = () => {

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -37,20 +37,27 @@ class UserDetails extends Component {
   };
 
   componentDidMount() {
-    this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
-    this.getUser();
-    this.getGroups();
-
-    this.getUserMemberOf();
-
-    this.interval = setInterval(() => this.getUserMemberOf(), 1000);
+    this.getAuthorisedBackendData();
   }
 
   componentWillUnmount() {
     clearInterval(this.interval);
   }
 
-  getUser = async () => {
+  getAuthorisedBackendData = async () => {
+    const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
+    this.getUser(authorisedActivities);
+    this.getGroups(authorisedActivities);
+
+    this.getUserMemberOf(authorisedActivities);
+
+    this.interval = setInterval(
+      () => this.getUserMemberOf(authorisedActivities),
+      1000
+    );
+  };
+
+  getUser = async (authorisedActivities) => {
     const userResponse = await fetch(`/api/users/${this.props.userId}`);
 
     const userJson = await userResponse.json();
@@ -60,7 +67,7 @@ class UserDetails extends Component {
     });
   };
 
-  getUserMemberOf = async () => {
+  getUserMemberOf = async (authorisedActivities) => {
     const userMemberOfResponse = await fetch(
       `/api/userGroupMembers/?userId=${this.props.userId}`
     );
@@ -72,7 +79,7 @@ class UserDetails extends Component {
     });
   };
 
-  getGroups = async () => {
+  getGroups = async (authorisedActivities) => {
     const groupsResponse = await fetch("/api/userGroups");
 
     const groupsJson = await groupsResponse.json();
@@ -95,6 +102,8 @@ class UserDetails extends Component {
       authorisedActivities: authorisedActivities,
       isLoading: false,
     });
+
+    return authorisedActivities;
   };
 
   openJoinGroupDialog = () => {

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -58,6 +58,8 @@ class UserDetails extends Component {
   };
 
   getUser = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const userResponse = await fetch(`/api/users/${this.props.userId}`);
 
     const userJson = await userResponse.json();
@@ -68,6 +70,8 @@ class UserDetails extends Component {
   };
 
   getUserMemberOf = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const userMemberOfResponse = await fetch(
       `/api/userGroupMembers/?userId=${this.props.userId}`
     );
@@ -80,6 +84,8 @@ class UserDetails extends Component {
   };
 
   getGroups = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
     const groupsResponse = await fetch("/api/userGroups");
 
     const groupsJson = await groupsResponse.json();

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -1,4 +1,4 @@
-export const getAllPrintTemplates = async () => {
+export const getAllPrintTemplates = async (authorisedActivities) => {
   const response = await fetch("/api/printTemplates");
   const templateJson = await response.json();
 
@@ -7,7 +7,7 @@ export const getAllPrintTemplates = async () => {
   return templatePackCodes;
 };
 
-export const getAllSmsTemplates = async () => {
+export const getAllSmsTemplates = async (authorisedActivities) => {
   const response = await fetch("/api/smsTemplates");
   const templateJson = await response.json();
 
@@ -16,7 +16,10 @@ export const getAllSmsTemplates = async () => {
   return templatePackCodes;
 };
 
-export const getFulfilmentPrintTemplates = async (surveyId) => {
+export const getFulfilmentPrintTemplates = async (
+  authorisedActivities,
+  surveyId
+) => {
   const response = await fetch(
     `/api/fulfilmentSurveyPrintTemplates/?surveyId=${surveyId}`
   );
@@ -25,7 +28,10 @@ export const getFulfilmentPrintTemplates = async (surveyId) => {
   return printTemplatesJson;
 };
 
-export const getSmsFulfilmentTemplates = async (surveyId) => {
+export const getSmsFulfilmentTemplates = async (
+  authorisedActivities,
+  surveyId
+) => {
   const response = await fetch(
     `/api/fulfilmentSurveySmsTemplates/?surveyId=${surveyId}`
   );
@@ -34,7 +40,10 @@ export const getSmsFulfilmentTemplates = async (surveyId) => {
   return smsFulfilmentTemplatesJson;
 };
 
-export const getActionRulePrintTemplates = async (surveyId) => {
+export const getActionRulePrintTemplates = async (
+  authorisedActivities,
+  surveyId
+) => {
   const response = await fetch(
     `/api/actionRuleSurveyPrintTemplates/?surveyId=${surveyId}`
   );
@@ -43,7 +52,10 @@ export const getActionRulePrintTemplates = async (surveyId) => {
   return printTemplatesJson;
 };
 
-export const getActionRuleSmsTemplates = async (surveyId) => {
+export const getActionRuleSmsTemplates = async (
+  authorisedActivities,
+  surveyId
+) => {
   const response = await fetch(
     `/api/actionRuleSurveySmsTemplates/?surveyId=${surveyId}`
   );
@@ -52,7 +64,10 @@ export const getActionRuleSmsTemplates = async (surveyId) => {
   return smsTemplatesJson;
 };
 
-export const getSensitiveSampleColumns = async (surveyId) => {
+export const getSensitiveSampleColumns = async (
+  authorisedActivities,
+  surveyId
+) => {
   const response = await fetch(`/api/surveys/${surveyId}`);
   if (!response.ok) {
     return;

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -1,4 +1,7 @@
 export const getAllPrintTemplates = async (authorisedActivities) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (!authorisedActivities.includes("LIST_PRINT_TEMPLATES")) return [];
+
   const response = await fetch("/api/printTemplates");
   const templateJson = await response.json();
 
@@ -8,6 +11,9 @@ export const getAllPrintTemplates = async (authorisedActivities) => {
 };
 
 export const getAllSmsTemplates = async (authorisedActivities) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (!authorisedActivities.includes("LIST_SMS_TEMPLATES")) return [];
+
   const response = await fetch("/api/smsTemplates");
   const templateJson = await response.json();
 
@@ -20,6 +26,14 @@ export const getFulfilmentPrintTemplates = async (
   authorisedActivities,
   surveyId
 ) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (
+    !authorisedActivities.includes(
+      "LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS"
+    )
+  )
+    return [];
+
   const response = await fetch(
     `/api/fulfilmentSurveyPrintTemplates/?surveyId=${surveyId}`
   );
@@ -32,6 +46,12 @@ export const getSmsFulfilmentTemplates = async (
   authorisedActivities,
   surveyId
 ) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (
+    !authorisedActivities.includes("LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS")
+  )
+    return [];
+
   const response = await fetch(
     `/api/fulfilmentSurveySmsTemplates/?surveyId=${surveyId}`
   );
@@ -44,6 +64,14 @@ export const getActionRulePrintTemplates = async (
   authorisedActivities,
   surveyId
 ) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (
+    !authorisedActivities.includes(
+      "LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES"
+    )
+  )
+    return [];
+
   const response = await fetch(
     `/api/actionRuleSurveyPrintTemplates/?surveyId=${surveyId}`
   );
@@ -56,6 +84,12 @@ export const getActionRuleSmsTemplates = async (
   authorisedActivities,
   surveyId
 ) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (
+    !authorisedActivities.includes("LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES")
+  )
+    return [];
+
   const response = await fetch(
     `/api/actionRuleSurveySmsTemplates/?surveyId=${surveyId}`
   );
@@ -68,6 +102,9 @@ export const getSensitiveSampleColumns = async (
   authorisedActivities,
   surveyId
 ) => {
+  // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
+  if (!authorisedActivities.includes("VIEW_SURVEY")) return [];
+
   const response = await fetch(`/api/surveys/${surveyId}`);
   if (!response.ok) {
     return;


### PR DESCRIPTION
# Motivation and Context
There are two parts to securing a single-page application: 1. Don't display parts of the UI which the user isn't authorised to see, and 2. Don't call APIs which the user isn't authorised to use. We were doing the first, but not the second.

# What has changed
Added checks to make sure user is authorised before calling all APIs.

# How to test?
Try accessing the UI with the reduced permissions and check that it doesn't crash anywhere, now that it's not going to the backend for a bunch of data.

# Links
Trello: https://trello.com/c/HhliKdR2