### PR TITLE
Originating user for new case events are the person who clicked process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.3.1-SNAPSHOT</version>
+      <version>2.4.0-HUGH</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>2.4.0-HUGH</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -191,6 +192,8 @@ public class JobEndpoint {
     if (job.getJobStatus() == JobStatus.VALIDATED_OK
         || job.getJobStatus() == JobStatus.VALIDATED_WITH_ERRORS) {
       job.setJobStatus(JobStatus.PROCESSING_IN_PROGRESS);
+      job.setProcessedBy(userEmail);
+      job.setProcessedAt(OffsetDateTime.now());
       jobRepository.saveAndFlush(job);
     } else {
       throw new ResponseStatusException(
@@ -210,6 +213,8 @@ public class JobEndpoint {
     if (job.getJobStatus() == JobStatus.VALIDATED_OK
         || job.getJobStatus() == JobStatus.VALIDATED_WITH_ERRORS) {
       job.setJobStatus(JobStatus.CANCELLED);
+      job.setCancelledBy(userEmail);
+      job.setCancelledAt(OffsetDateTime.now());
       jobRepository.saveAndFlush(job);
 
       jobRowRepository.deleteByJobAndAndJobRowStatus(job, JobRowStatus.VALIDATED_OK);
@@ -275,6 +280,10 @@ public class JobEndpoint {
     jobDto.setProcessedRowCount(job.getProcessingRowNumber());
     jobDto.setRowErrorCount(job.getErrorRowCount());
     jobDto.setFatalErrorDescription(job.getFatalErrorDescription());
+    jobDto.setProcessedBy(job.getProcessedBy());
+    jobDto.setProcessedAt(job.getProcessedAt());
+    jobDto.setCancelledBy(job.getCancelledBy());
+    jobDto.setCancelledAt(job.getCancelledAt());
     return jobDto;
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/JobDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/JobDto.java
@@ -22,4 +22,10 @@ public class JobDto {
   private JobStatusDto jobStatus;
 
   private String fatalErrorDescription;
+
+  private String processedBy;
+  private OffsetDateTime processedAt;
+
+  private String cancelledBy;
+  private OffsetDateTime cancelledAt;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -37,7 +37,7 @@ public class UserIdentity {
   public void checkUserPermission(
       String userEmail, Survey survey, UserGroupAuthorisedActivityType activity) {
     // TODO: Remove this before releasing to production!
-    if (userEmail.equals("one-more-user@fake-email.com")) {
+    if (userEmail.equals("dummy@fake-email.com")) {
       return; // User is authorised - hack workaround for ease of dev/testing... remember to remove!
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -37,7 +37,7 @@ public class UserIdentity {
   public void checkUserPermission(
       String userEmail, Survey survey, UserGroupAuthorisedActivityType activity) {
     // TODO: Remove this before releasing to production!
-    if (userEmail.equals("dummy@fake-email.com")) {
+    if (userEmail.equals("one-more-user@fake-email.com")) {
       return; // User is authorised - hack workaround for ease of dev/testing... remember to remove!
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/NewCaseTransformer.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/NewCaseTransformer.java
@@ -40,7 +40,7 @@ public class NewCaseTransformer implements Transformer {
     payloadDTO.setNewCase(newCase);
 
     EventDTO event = new EventDTO();
-    EventHeaderDTO eventHeader = EventHelper.createEventDTO(topic, job.getCreatedBy());
+    EventHeaderDTO eventHeader = EventHelper.createEventDTO(topic, job.getProcessedBy());
     eventHeader.setCorrelationId(job.getId());
     event.setHeader(eventHeader);
     event.setPayload(payloadDTO);

--- a/ui/src/JobDetails.js
+++ b/ui/src/JobDetails.js
@@ -150,6 +150,50 @@ class JobDetails extends Component {
               Uploaded by: {this.props.job.createdBy}
             </Typography>
           </Grid>
+          {this.props.job.processedAt && (
+            <Grid container item xs={12}>
+              <Grid container item xs={12} spacing={3}>
+                <Typography
+                  variant="inherit"
+                  color="inherit"
+                  style={{ margin: 10, padding: 10 }}
+                >
+                  Processed at: {this.props.job.processedAt}
+                </Typography>
+              </Grid>
+              <Grid container item xs={12} spacing={3}>
+                <Typography
+                  variant="inherit"
+                  color="inherit"
+                  style={{ margin: 10, padding: 10 }}
+                >
+                  Processed by: {this.props.job.processedBy}
+                </Typography>
+              </Grid>
+            </Grid>
+          )}
+          {this.props.job.cancelledAt && (
+            <Grid container item xs={12}>
+              <Grid container item xs={12} spacing={3}>
+                <Typography
+                  variant="inherit"
+                  color="inherit"
+                  style={{ margin: 10, padding: 10 }}
+                >
+                  Cancelled at: {this.props.job.cancelledAt}
+                </Typography>
+              </Grid>
+              <Grid container item xs={12} spacing={3}>
+                <Typography
+                  variant="inherit"
+                  color="inherit"
+                  style={{ margin: 10, padding: 10 }}
+                >
+                  Cancelled by: {this.props.job.cancelledBy}
+                </Typography>
+              </Grid>
+            </Grid>
+          )}
         </Grid>
       );
     }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support Tool user who clicked "Process" sample button should be originating user of newCase events
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
New case events have the user who pressed process as the originating user.
Job details pop up will say who either processed it or cancelled the job.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
To check the processed by stuff:

1. Build the image and `make up` in docker dev
2. Stop the case processor in docker dev (`docker stop caseprocessor`)
3. Load a sample, let it validate but don't process immediately.
4. Change the user you're working as.
5. Process the sample file
6. Check the user you're acting as and the time you clicked process show up on the job details window
7. In the docker dev repo ` ./get_message.sh event_new-case_rm-case-processor shared-project` and check the originating user in the JSON is the user you changed to to process the job.

To check the cancelled by stuff:

1. Do as above up to step 5 (no need to stop the case processor)
2. Go into the jobs detail page and click cancel
3. Check that the user you're acting as and the time you clicked cancel show up on the job details window

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/DMFLX8em/2878-support-tool-user-who-clicked-process-sample-button-should-be-originating-user-of-newcase-events-8
# Screenshots (if appropriate):
