### PR TITLE
Use job row ID for case ID instead of random ID

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
@@ -60,8 +60,7 @@ public class RowChunkProcessor {
 
         ListenableFuture<String> future =
             pubSubTemplate.publish(
-                topic,
-                TRANSFORMER.transformRow(jobRow.getRowData(), job, columnValidators, newCaseTopic));
+                topic, TRANSFORMER.transformRow(job, jobRow, columnValidators, newCaseTopic));
 
         // Wait for up to 30 seconds to confirm that message was published
         future.get(30, TimeUnit.SECONDS);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/NewCaseTransformer.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/NewCaseTransformer.java
@@ -2,8 +2,8 @@ package uk.gov.ons.ssdc.supporttool.transformer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import uk.gov.ons.ssdc.common.model.entity.Job;
+import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
 import uk.gov.ons.ssdc.supporttool.model.dto.messaging.EventDTO;
 import uk.gov.ons.ssdc.supporttool.model.dto.messaging.EventHeaderDTO;
@@ -14,9 +14,12 @@ import uk.gov.ons.ssdc.supporttool.utility.EventHelper;
 public class NewCaseTransformer implements Transformer {
   @Override
   public Object transformRow(
-      Map<String, String> rowData, Job job, ColumnValidator[] columnValidators, String topic) {
+      Job job, JobRow jobRow, ColumnValidator[] columnValidators, String topic) {
+
+    Map<String, String> rowData = jobRow.getRowData();
+
     NewCase newCase = new NewCase();
-    newCase.setCaseId(UUID.randomUUID());
+    newCase.setCaseId(jobRow.getId()); // Use row ID so we get no dupes if support tool crashes
     newCase.setCollectionExerciseId(job.getCollectionExercise().getId());
 
     Map<String, String> nonSensitiveSampleData = new HashMap<>();

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/Transformer.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/transformer/Transformer.java
@@ -1,10 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.transformer;
 
-import java.util.Map;
 import uk.gov.ons.ssdc.common.model.entity.Job;
+import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
 
 public interface Transformer {
-  Object transformRow(
-      Map<String, String> rowData, Job job, ColumnValidator[] columnValidators, String topic);
+  Object transformRow(Job job, JobRow jobRow, ColumnValidator[] columnValidators, String topic);
 }


### PR DESCRIPTION
# Motivation and Context
If the support tool backend is rebooted during a sample load, it will resend any of the cases in the batch it was in the middle of processing, which will create some dupes (between 1 and 500).

# What has changed
If we use the job row ID as the case ID then any dupes will be rejected, because Case Processor checks to see if the case ID exists before storing the case.

# How to test?
Load a sample. If you wanna get fancy, load a sample and restart the support tool while it's processing, then check that there are no extra cases created.

# Links
Trello: https://trello.com/c/Fcg2cl2b