### PR TITLE
Don't destroy data which was carefully retrieved from the backend

### DIFF
--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -52,7 +52,6 @@ class PrintFulfilment extends Component {
   closeDialog = () => {
     this.setState({
       packCode: "",
-      allowableFulfilmentPrintTemplates: [],
       packCodeValidationError: false,
       showDialog: false,
     });

--- a/ui/src/SmsFulfilment.js
+++ b/ui/src/SmsFulfilment.js
@@ -56,7 +56,6 @@ class SmsFulfilment extends Component {
   closeDialog = () => {
     this.setState({
       packCode: "",
-      allowableSmsFulfilmentTemplates: [],
       packCodeValidationError: false,
       showDialog: false,
       newValueValidationError: "",


### PR DESCRIPTION
# Motivation and Context
Forms should be blanked and ready to fill in when they're opened. No need to format the hard disk and set fire to all the computers after a user clicks the "OK" button.

# What has changed
No longer destroy the entire universe, just because somebody clicked "OK".

# How to test?
Does the universe end anymore, after the "OK" button is clicked, or is it actually possible to use the dialog box a second time?

# Links
Trello: https://trello.com/c/irMan9BI