### PR TITLE
Add table headings to improve UI for non-superusers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>ssdc-rm-common-entity-model</artifactId>
       <version>3.2.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>uk.gov.ons.ssdc</groupId>
+      <artifactId>ssdc-shared-sample-validation</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,6 @@
       <artifactId>ssdc-rm-common-entity-model</artifactId>
       <version>3.2.1-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>uk.gov.ons.ssdc</groupId>
-      <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -407,29 +407,34 @@ class CollectionExerciseDetails extends Component {
         <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
           Collection Exercise Details - {this.state.collectionExerciseName}
         </Typography>
+        {this.state.authorisedActivities.includes("LIST_ACTION_RULES") && (
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Action Rules
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Type</TableCell>
+                    <TableCell>Trigger date</TableCell>
+                    <TableCell>Has triggered?</TableCell>
+                    <TableCell>UAC Metadata</TableCell>
+                    <TableCell>Classifiers</TableCell>
+                    <TableCell>Pack Code</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{actionRuleTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {allowedActionRuleTypeMenuItems.length > 0 && (
-          <div style={{ marginTop: 20 }}>
+          <div style={{ marginTop: 10 }}>
             <Button variant="contained" onClick={this.openDialog}>
               Create Action Rule
             </Button>
           </div>
-        )}
-        {this.state.authorisedActivities.includes("LIST_ACTION_RULES") && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Type</TableCell>
-                  <TableCell>Trigger date</TableCell>
-                  <TableCell>Has triggered?</TableCell>
-                  <TableCell>UAC Metadata</TableCell>
-                  <TableCell>Classifiers</TableCell>
-                  <TableCell>Pack Code</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{actionRuleTableRows}</TableBody>
-            </Table>
-          </TableContainer>
         )}
         {(this.state.authorisedActivities.includes("LOAD_SAMPLE") ||
           this.state.authorisedActivities.includes(

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -10,6 +10,7 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Typography,
 } from "@material-ui/core";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -506,70 +507,91 @@ class LandingPage extends Component {
 
     return (
       <div style={{ padding: 20 }}>
+        {this.state.authorisedActivities.includes("LIST_SURVEYS") && (
+          <>
+            <Typography variant="h6" color="inherit">
+              Surveys
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Survey Name</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{surveyTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {this.state.authorisedActivities.includes("CREATE_SURVEY") && (
-          <Button variant="contained" onClick={this.openDialog}>
+          <Button
+            variant="contained"
+            onClick={this.openDialog}
+            style={{ marginTop: 10 }}
+          >
             Create Survey
           </Button>
         )}
-        {this.state.authorisedActivities.includes("LIST_SURVEYS") && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Survey Name</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{surveyTableRows}</TableBody>
-            </Table>
-          </TableContainer>
+
+        {this.state.authorisedActivities.includes("LIST_PRINT_TEMPLATES") && (
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 10 }}>
+              Print Templates
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                    <TableCell>Print Supplier</TableCell>
+                    <TableCell>Template</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{printTemplateRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
         {this.state.authorisedActivities.includes("CREATE_PRINT_TEMPLATE") && (
           <Button
             variant="contained"
             onClick={this.openPrintTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Create Print Template
           </Button>
         )}
-        {this.state.authorisedActivities.includes("LIST_PRINT_TEMPLATES") && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                  <TableCell>Print Supplier</TableCell>
-                  <TableCell>Template</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{printTemplateRows}</TableBody>
-            </Table>
-          </TableContainer>
-        )}
 
+        {this.state.authorisedActivities.includes("LIST_SMS_TEMPLATES") && (
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 10 }}>
+              SMS Templates
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                    <TableCell>Template</TableCell>
+                    <TableCell>Gov Notify Template ID</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{smsTemplateRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {this.state.authorisedActivities.includes("CREATE_SMS_TEMPLATE") && (
           <Button
             variant="contained"
             onClick={this.openSmsTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Create sms Template
           </Button>
         )}
-        {this.state.authorisedActivities.includes("LIST_SMS_TEMPLATES") && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                  <TableCell>Template</TableCell>
-                  <TableCell>Gov Notify Template ID</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{smsTemplateRows}</TableBody>
-            </Table>
-          </TableContainer>
-        )}
+
         {this.state.authorisedActivities.includes(
           "CONFIGURE_FULFILMENT_TRIGGER"
         ) && (

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -180,6 +180,27 @@ class SampleUpload extends Component {
 
     return (
       <div style={{ marginTop: 20 }}>
+        {this.props.authorisedActivities.includes(
+          "VIEW_SAMPLE_LOAD_PROGRESS"
+        ) && (
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Uploaded Sample Files
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>File Name</TableCell>
+                    <TableCell>Date Uploaded</TableCell>
+                    <TableCell align="right">Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{jobTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {this.props.authorisedActivities.includes("LOAD_SAMPLE") && (
           <>
             <input
@@ -192,27 +213,15 @@ class SampleUpload extends Component {
               }}
             />
             <label htmlFor="contained-button-file">
-              <Button variant="contained" component="span">
+              <Button
+                variant="contained"
+                component="span"
+                style={{ marginTop: 10 }}
+              >
                 Upload Sample File
               </Button>
             </label>
           </>
-        )}
-        {this.props.authorisedActivities.includes(
-          "VIEW_SAMPLE_LOAD_PROGRESS"
-        ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>File Name</TableCell>
-                  <TableCell>Date Uploaded</TableCell>
-                  <TableCell align="right">Status</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{jobTableRows}</TableBody>
-            </Table>
-          </TableContainer>
         )}
         <Dialog open={this.state.uploadInProgress}>
           <DialogContent style={{ padding: 30 }}>

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -494,25 +494,54 @@ class SurveyDetails extends Component {
           </div>
         )}
         {this.state.authorisedActivities.includes(
+          "LIST_COLLECTION_EXERCISES"
+        ) && (
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 10 }}>
+              Collection Exercises
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Collection Exercise Name</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{collectionExerciseTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
+        {this.state.authorisedActivities.includes(
           "CREATE_COLLECTION_EXERCISE"
         ) && (
-          <Button variant="contained" onClick={this.openDialog}>
+          <Button
+            variant="contained"
+            onClick={this.openDialog}
+            style={{ marginTop: 10 }}
+          >
             Create Collection Exercise
           </Button>
         )}
+
         {this.state.authorisedActivities.includes(
-          "LIST_COLLECTION_EXERCISES"
+          "LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES"
         ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Collection Exercise Name</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{collectionExerciseTableRows}</TableBody>
-            </Table>
-          </TableContainer>
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Print Templates Allowed on Action Rules
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{actionRulePrintTemplateTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
         {this.state.authorisedActivities.includes(
           "ALLOW_PRINT_TEMPLATE_ON_ACTION_RULE"
@@ -520,24 +549,30 @@ class SurveyDetails extends Component {
           <Button
             variant="contained"
             onClick={this.openActionRulePrintTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Allow Print Template on Action Rule
           </Button>
         )}
+
         {this.state.authorisedActivities.includes(
-          "LIST_ALLOWED_PRINT_TEMPLATES_ON_ACTION_RULES"
+          "LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES"
         ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{actionRulePrintTemplateTableRows}</TableBody>
-            </Table>
-          </TableContainer>
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              SMS Templates Allowed on Action Rules
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{actionRuleSmsTemplateTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
         {this.state.authorisedActivities.includes(
           "ALLOW_SMS_TEMPLATE_ON_ACTION_RULE"
@@ -545,24 +580,30 @@ class SurveyDetails extends Component {
           <Button
             variant="contained"
             onClick={this.openActionRuleSmsTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Allow SMS Template on Action Rule
           </Button>
         )}
+
         {this.state.authorisedActivities.includes(
-          "LIST_ALLOWED_SMS_TEMPLATES_ON_ACTION_RULES"
+          "LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS"
         ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{actionRuleSmsTemplateTableRows}</TableBody>
-            </Table>
-          </TableContainer>
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Print Templates Allowed on Fulfilments
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{fulfilmentPrintTemplateTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
         {this.state.authorisedActivities.includes(
           "ALLOW_PRINT_TEMPLATE_ON_FULFILMENT"
@@ -570,24 +611,30 @@ class SurveyDetails extends Component {
           <Button
             variant="contained"
             onClick={this.openFulfilmentPrintTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Allow Print Template on Fulfilment
           </Button>
         )}
+
         {this.state.authorisedActivities.includes(
-          "LIST_ALLOWED_PRINT_TEMPLATES_ON_FULFILMENTS"
+          "LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS"
         ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{fulfilmentPrintTemplateTableRows}</TableBody>
-            </Table>
-          </TableContainer>
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              SMS Templates Allowed on Fulfilments
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Pack Code</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{smsFulfilmentTemplateTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
         {this.state.authorisedActivities.includes(
           "ALLOW_SMS_TEMPLATE_ON_FULFILMENT"
@@ -595,25 +642,12 @@ class SurveyDetails extends Component {
           <Button
             variant="contained"
             onClick={this.openSmsFulfilmentTemplateDialog}
-            style={{ marginTop: 20 }}
+            style={{ marginTop: 10 }}
           >
             Allow SMS Template on Fulfilment
           </Button>
         )}
-        {this.state.authorisedActivities.includes(
-          "LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS"
-        ) && (
-          <TableContainer component={Paper} style={{ marginTop: 20 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Pack Code</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>{smsFulfilmentTemplateTableRows}</TableBody>
-            </Table>
-          </TableContainer>
-        )}
+
         <Dialog open={this.state.createCollectionExerciseDialogDisplayed}>
           <DialogContent style={{ padding: 30 }}>
             <div>


### PR DESCRIPTION
# Motivation and Context
It's hard to use the UI if you're not a super user.

# What has changed
Added table headings.

# How to test?
Try it as a non-super-user (e.g. with RM SUPPORT group)

# Links
Trello: https://trello.com/c/4b22QCDM

# Screenshots (if appropriate):
<img width="1060" alt="Screenshot 2021-10-07 at 16 34 35" src="https://user-images.githubusercontent.com/41681172/136417566-3788ee71-fe9d-4482-8487-f40a9fca8974.png">
<img width="1063" alt="Screenshot 2021-10-07 at 16 35 26" src="https://user-images.githubusercontent.com/41681172/136417573-4b8f4ce6-8944-4114-8ce2-34d100449fce.png">
<img width="1059" alt="Screenshot 2021-10-07 at 16 35 41" src="https://user-images.githubusercontent.com/41681172/136417580-2448e172-40fa-4783-a6ee-409eb76f4bed.png">
