### PR TITLE
Fix to allow sensitive data to be blanked out for GDPR compliance

### DIFF
--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -176,12 +176,12 @@ class CaseDetails extends Component {
         <Link to={`/search?surveyId=${this.props.surveyId}`}>
           ← Back to Search
         </Link>
-        <Typography variant="h4" color="inherit">
+        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
           Case Details
         </Typography>
         {this.state.case && (
           <div>
-            <TableContainer component={Paper}>
+            <TableContainer component={Paper} style={{ marginTop: 20 }}>
               <Table>
                 <TableHead>
                   <TableRow>
@@ -247,10 +247,7 @@ class CaseDetails extends Component {
                 </TableBody>
               </Table>
             </TableContainer>
-            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-              Event History
-            </Typography>
-            <TableContainer component={Paper}>
+            <TableContainer component={Paper} style={{ marginTop: 20 }}>
               <Table>
                 <TableHead>
                   <TableRow>
@@ -263,10 +260,7 @@ class CaseDetails extends Component {
                 <TableBody>{caseEvents}</TableBody>
               </Table>
             </TableContainer>
-            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-              UACs and QIDs
-            </Typography>
-            <TableContainer component={Paper}>
+            <TableContainer component={Paper} style={{ marginTop: 20 }}>
               <Table>
                 <TableHead>
                   <TableRow>


### PR DESCRIPTION
# Motivation and Context
We want validation rules for sample load, but these can be unwanted when we are trying to blank out a piece of data, to comply with GDPR.

# What has changed
Skip the validation rules if the user is trying to blank out a piece of PII.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/sxPPab1X
