### PR TITLE
2787 Protect against duplicate groups and permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>3.3.0-SNAPSHOT</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
@@ -66,6 +66,10 @@ public class UserGroupEndpoint {
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
 
+    if (userGroupRepository.existsByName(userGroupDto.getName())) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Group name already exists");
+    }
+
     UserGroup userGroup = new UserGroup();
     userGroup.setId(UUID.randomUUID());
     userGroup.setName(userGroupDto.getName());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
@@ -87,6 +87,12 @@ public class UserGroupMemberEndpoint {
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
+    if (user.getMemberOf().stream()
+        .anyMatch(userGroupMember -> userGroupMember.getGroup() == group)) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "User is already a member of this group");
+    }
+
     UserGroupMember userGroupMember = new UserGroupMember();
     userGroupMember.setId(UUID.randomUUID());
     userGroupMember.setUser(user);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -99,9 +99,9 @@ public class UserGroupPermissionEndpoint {
       if (existingPermission
               .getAuthorisedActivity()
               .equals(userGroupPermissionDto.getAuthorisedActivity())
-          && (survey == null && existingPermission.getSurvey() == null
-              || existingPermission.getSurvey() != null
-                  && existingPermission.getSurvey().equals(survey))) {
+          && ((survey == null && existingPermission.getSurvey() == null)
+              || (existingPermission.getSurvey() != null
+                  && existingPermission.getSurvey().equals(survey)))) {
         throw new ResponseStatusException(HttpStatus.CONFLICT, "Permission already exists");
       }
     }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -96,8 +96,8 @@ public class UserGroupPermissionEndpoint {
     }
 
     for (UserGroupPermission existingPermission : group.getPermissions()) {
-      // Check if both the activity and survey are equal to any existing permission
-      // Note: Either survey can be null, so the survey comparison must be null safe on both sides
+      // Check if both the activity and survey are equal to any existing permission on this group
+      // Note: Either survey can be null, so the survey comparison must be null safe on both values
       if (existingPermission
               .getAuthorisedActivity()
               .equals(userGroupPermissionDto.getAuthorisedActivity())

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -95,6 +95,17 @@ public class UserGroupPermissionEndpoint {
                   () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Survey not found"));
     }
 
+    for (UserGroupPermission existingPermission : group.getPermissions()) {
+      if (existingPermission
+              .getAuthorisedActivity()
+              .equals(userGroupPermissionDto.getAuthorisedActivity())
+          && (survey == null && existingPermission.getSurvey() == null
+              || existingPermission.getSurvey() != null
+                  && existingPermission.getSurvey().equals(survey))) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "Permission already exists");
+      }
+    }
+
     UserGroupPermission userGroupPermission = new UserGroupPermission();
     userGroupPermission.setId(UUID.randomUUID());
     userGroupPermission.setGroup(group);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -96,6 +96,8 @@ public class UserGroupPermissionEndpoint {
     }
 
     for (UserGroupPermission existingPermission : group.getPermissions()) {
+      // Check if both the activity and survey are equal to any existing permission
+      // Note: Either survey can be null, so the survey comparison must be null safe on both sides
       if (existingPermission
               .getAuthorisedActivity()
               .equals(userGroupPermissionDto.getAuthorisedActivity())

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupRepository.java
@@ -4,4 +4,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.UserGroup;
 
-public interface UserGroupRepository extends JpaRepository<UserGroup, UUID> {}
+public interface UserGroupRepository extends JpaRepository<UserGroup, UUID> {
+
+  boolean existsByName(String name);
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -345,7 +345,7 @@ public class AllEndpointsIT {
         (bundle) -> "userGroups",
         (bundle) -> {
           UserGroupDto userGroupDto = new UserGroupDto();
-          userGroupDto.setName("Test");
+          userGroupDto.setName("TEST_GROUP_" + UUID.randomUUID());
           return userGroupDto;
         });
   }
@@ -364,7 +364,7 @@ public class AllEndpointsIT {
         (bundle) -> {
           UserGroupMemberDto userGroupMemberDto = new UserGroupMemberDto();
           userGroupMemberDto.setUserId(bundle.getUserId());
-          userGroupMemberDto.setGroupId(bundle.getGroupId());
+          userGroupMemberDto.setGroupId(bundle.getSecondGroupId());
           return userGroupMemberDto;
         });
 

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
@@ -15,4 +15,5 @@ public class BundleOfUsefulTestStuff {
   private UUID groupId;
   private UUID groupMemberId;
   private UUID groupPermissionId;
+  private UUID secondGroupId;
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -190,6 +190,7 @@ public class IntegrationTestHelper {
 
     User user = setupDummyUser(UUID.randomUUID());
     UserGroup group = setupDummyGroup(UUID.randomUUID());
+    UserGroup secondGroup = setupDummyGroup(UUID.randomUUID());
     UserGroupMember userGroupMember = setupDummyGroupMember(UUID.randomUUID(), user, group);
     UserGroupPermission userGroupPermission = setupDummyGroupPermission(UUID.randomUUID(), group);
 
@@ -204,6 +205,7 @@ public class IntegrationTestHelper {
     bundle.setGroupId(group.getId());
     bundle.setGroupMemberId(userGroupMember.getId());
     bundle.setGroupPermissionId(userGroupPermission.getId());
+    bundle.setSecondGroupId(secondGroup.getId());
 
     return bundle;
   }
@@ -226,7 +228,7 @@ public class IntegrationTestHelper {
   private UserGroup setupDummyGroup(UUID groupId) {
     UserGroup group = new UserGroup();
     group.setId(groupId);
-    group.setName("Test");
+    group.setName("TEST_GROUP_" + groupId);
     group = userGroupRepository.saveAndFlush(group);
     return group;
   }

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -178,12 +178,12 @@ class GroupDetails extends Component {
     let allowedSurveys = [];
     if (!existingPermissionSurveyIds.includes(null)) {
       // For global permissions
-      allowedSurveys = allowedSurveys.concat(null);
+      allowedSurveys.push(null);
     }
-    allowedSurveys = allowedSurveys.concat(
-      this.state.allSurveys
+    allowedSurveys.push(
+      ...this.state.allSurveys
         .filter((survey) => !existingPermissionSurveyIds.includes(survey.id))
-        .sort((a, b) => (a.surveyName > b.surveyName ? 1 : -1))
+        .sort((a, b) => a.name.localeCompare(b.name)) // Sort by survey name alphabetically
     );
 
     this.setState({

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -292,7 +292,6 @@ class GroupDetails extends Component {
     );
 
     const activityMenuItems = this.state.allActivities
-      .filter((activity) => !this.state.groupActivities.includes(activity))
       .sort()
       .map((activity) => {
         return (

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -21,6 +21,7 @@ import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 
+const globalSurveyId = "GLOBAL";
 class GroupDetails extends Component {
   state = {
     authorisedActivities: [],
@@ -29,12 +30,14 @@ class GroupDetails extends Component {
     groupActivities: [],
     allActivities: [],
     allSurveys: [],
+    allowedSurveys: [],
     showAllowDialog: false,
     showRemoveDialog: false,
     activity: null,
     activityValidationError: false,
     surveyId: null,
     surveyName: null,
+    surveyValidationError: false,
     userGroupPermissionId: null,
   };
 
@@ -127,6 +130,7 @@ class GroupDetails extends Component {
     this.setState({
       activity: null,
       activityValidationError: false,
+      surveyValidationError: false,
       surveyId: null,
       showAllowDialog: true,
     });
@@ -164,8 +168,26 @@ class GroupDetails extends Component {
   };
 
   onActivityChange = (event) => {
+    const existingPermissionSurveyIds = this.state.groupActivities
+      .filter((activity) => activity.authorisedActivity === event.target.value)
+      .map((permission) => permission.surveyId);
+
+    // Build the list of surveys this activity is not already allowed on
+    let allowedSurveys = [];
+    if (!existingPermissionSurveyIds.includes(null)) {
+      // For global permissions
+      allowedSurveys = allowedSurveys.concat(null);
+    }
+    allowedSurveys = allowedSurveys.concat(
+      this.state.allSurveys
+        .filter((survey) => !existingPermissionSurveyIds.includes(survey.id))
+        .sort((a, b) => (a.surveyName > b.surveyName ? 1 : -1))
+    );
+
     this.setState({
       activity: event.target.value,
+      allowedSurveys: allowedSurveys,
+      surveyValidationError: false,
     });
   };
 
@@ -180,23 +202,57 @@ class GroupDetails extends Component {
       this.setState({
         activityValidationError: true,
       });
-
       return;
+    }
+    if (!this.state.surveyId) {
+      this.setState({
+        surveyValidationError: true,
+      });
+      return;
+    }
+
+    let surveyId;
+    if (this.state.surveyId === globalSurveyId) {
+      surveyId = null;
+    } else {
+      surveyId = this.state.surveyId;
     }
 
     const newUserGroupPermission = {
       authorisedActivity: this.state.activity,
       groupId: this.props.groupId,
-      surveyId: this.state.surveyId,
+      surveyId: surveyId,
     };
 
-    await fetch("/api/userGroupPermissions", {
+    const response = await fetch("/api/userGroupPermissions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(newUserGroupPermission),
     });
 
+    if (!response.ok) {
+      this.setState({
+        activityValidationError: true,
+      });
+      return;
+    }
+
     this.setState({ showAllowDialog: false });
+  };
+
+  buildSurveyMenuItem = (survey) => {
+    if (survey === null) {
+      return (
+        <MenuItem key="All Surveys" value={globalSurveyId}>
+          <i>All Surveys - Global permission</i>
+        </MenuItem>
+      );
+    }
+    return (
+      <MenuItem key={survey.id} value={survey.id}>
+        {survey.name}
+      </MenuItem>
+    );
   };
 
   render() {
@@ -233,19 +289,20 @@ class GroupDetails extends Component {
       }
     );
 
-    const activityMenuItems = this.state.allActivities.map((activity) => {
-      return (
-        <MenuItem key={activity} value={activity}>
-          {activity}
-        </MenuItem>
-      );
-    });
+    const activityMenuItems = this.state.allActivities
+      .filter((activity) => !this.state.groupActivities.includes(activity))
+      .sort()
+      .map((activity) => {
+        return (
+          <MenuItem key={activity} value={activity}>
+            {activity}
+          </MenuItem>
+        );
+      });
 
-    const surveyMenuItems = this.state.allSurveys.map((survey) => (
-      <MenuItem key={survey.id} value={survey.id}>
-        {survey.name}
-      </MenuItem>
-    ));
+    const surveyMenuItems = this.state.allowedSurveys.map((survey) =>
+      this.buildSurveyMenuItem(survey)
+    );
 
     return (
       <div style={{ padding: 20 }}>
@@ -272,7 +329,7 @@ class GroupDetails extends Component {
                   <TableRow>
                     <TableCell>Activity</TableCell>
                     <TableCell>Survey</TableCell>
-                    <TableCell></TableCell>
+                    <TableCell />
                   </TableRow>
                 </TableHead>
                 <TableBody>{groupActivitiesTableRows}</TableBody>
@@ -293,15 +350,18 @@ class GroupDetails extends Component {
                       {activityMenuItems}
                     </Select>
                   </FormControl>
-                  <FormControl fullWidth={true}>
-                    <InputLabel>Survey</InputLabel>
-                    <Select
-                      onChange={this.onSurveyChange}
-                      value={this.state.surveyId}
-                    >
-                      {surveyMenuItems}
-                    </Select>
-                  </FormControl>
+                  {this.state.activity && (
+                    <FormControl required fullWidth={true}>
+                      <InputLabel>Survey</InputLabel>
+                      <Select
+                        onChange={this.onSurveyChange}
+                        value={this.state.surveyId}
+                        error={this.state.surveyValidationError}
+                      >
+                        {surveyMenuItems}
+                      </Select>
+                    </FormControl>
+                  )}
                 </div>
                 <div style={{ marginTop: 10 }}>
                   <Button

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -243,7 +243,7 @@ class GroupDetails extends Component {
   buildSurveyMenuItem = (survey) => {
     if (survey === null) {
       return (
-        <MenuItem key="All Surveys" value={globalSurveyId}>
+        <MenuItem key={globalSurveyId} value={globalSurveyId}>
           <i>All Surveys - Global permission</i>
         </MenuItem>
       );

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -22,6 +22,8 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 
 const globalSurveyId = "GLOBAL";
+const globalSurveyLabel = "All Surveys - Global permission";
+
 class GroupDetails extends Component {
   state = {
     authorisedActivities: [],
@@ -244,7 +246,7 @@ class GroupDetails extends Component {
     if (survey === null) {
       return (
         <MenuItem key={globalSurveyId} value={globalSurveyId}>
-          <i>All Surveys - Global permission</i>
+          <i>{globalSurveyLabel}</i>
         </MenuItem>
       );
     }
@@ -260,7 +262,7 @@ class GroupDetails extends Component {
       (groupActivity, index) => {
         const surveyName = groupActivity.surveyId
           ? groupActivity.surveyName
-          : "All Surveys - Global permission";
+          : globalSurveyLabel;
 
         return (
           <TableRow key={index}>

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -27,6 +27,7 @@ class UserAdmin extends Component {
     showGroupDialog: false,
     groupName: "",
     groupNameValidationError: false,
+    groupNameValidationMessage: null,
   };
 
   componentDidMount() {
@@ -136,6 +137,7 @@ class UserAdmin extends Component {
     this.setState({
       groupName: "",
       groupNameValidationError: false,
+      groupNameValidationMessage: null,
       showGroupDialog: true,
     });
   };
@@ -154,7 +156,22 @@ class UserAdmin extends Component {
 
   onCreateGroup = async () => {
     if (!this.state.groupName.trim()) {
-      this.setState({ groupNameValidationError: true });
+      this.setState({
+        groupNameValidationError: true,
+        groupNameValidationMessage: "Group name is required",
+      });
+      return;
+    }
+
+    if (
+      this.state.groups
+        .map((group) => group.name)
+        .includes(this.state.groupName)
+    ) {
+      this.setState({
+        groupNameValidationError: true,
+        groupNameValidationMessage: "Group already exists",
+      });
       return;
     }
 
@@ -285,6 +302,7 @@ class UserAdmin extends Component {
                 label="Group name"
                 onChange={this.onGroupNameChange}
                 error={this.state.groupNameValidationError}
+                helperText={this.state.groupNameValidationMessage}
                 value={this.state.groupName}
               />
             </div>

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -203,11 +203,19 @@ class UserDetails extends Component {
       }
     );
 
-    const groupMenuItems = this.state.groups.map((group) => (
-      <MenuItem key={group.id} value={group.id}>
-        {group.name}
-      </MenuItem>
-    ));
+    const addGroupMenuItems = this.state.groups
+      .filter(
+        (group) =>
+          !this.state.memberOfGroups
+            .map((memberOfGroup) => memberOfGroup.groupId)
+            .includes(group.id)
+      )
+      .sort()
+      .map((group) => (
+        <MenuItem key={group.id} value={group.id}>
+          {group.name}
+        </MenuItem>
+      ));
 
     return (
       <div style={{ padding: 20 }}>
@@ -233,7 +241,7 @@ class UserDetails extends Component {
                 <TableHead>
                   <TableRow>
                     <TableCell>Group Name</TableCell>
-                    <TableCell></TableCell>
+                    <TableCell />
                   </TableRow>
                 </TableHead>
                 <TableBody>{memberOfGroupTableRows}</TableBody>
@@ -251,7 +259,7 @@ class UserDetails extends Component {
                       value={this.state.groupId}
                       error={this.state.groupValidationError}
                     >
-                      {groupMenuItems}
+                      {addGroupMenuItems}
                     </Select>
                   </FormControl>
                 </div>

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -210,7 +210,7 @@ class UserDetails extends Component {
             .map((memberOfGroup) => memberOfGroup.groupId)
             .includes(group.id)
       )
-      .sort()
+      .sort((a, b) => a.name.localeCompare(b.name)) // Sort by group name alphabetically
       .map((group) => (
         <MenuItem key={group.id} value={group.id}>
           {group.name}


### PR DESCRIPTION
# Motivation and Context
Neither the UI nor back end should allow duplicate permissions, groups or memberships. 

# What has changed
- Block duplicate groups, permissions and memberships in back end
- Block duplicate groups, permissions and memberships in front end

# How to test?
Try to create duplicate groups, permissions or memberships either with the UI or API directly.

# Links
https://trello.com/c/uMBMYfs8/2787-support-tool-duplicate-permissions
