### PR TITLE
Allow group admins to add and remove users

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupAdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupAdminEndpoint.java
@@ -1,0 +1,101 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.User;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAdmin;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupAdminDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupAdminRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserGroupRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.UserRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@RestController
+@RequestMapping(value = "/api/userGroupAdmins")
+public class UserGroupAdminEndpoint {
+  private final UserGroupAdminRepository userGroupAdminRepository;
+  private final UserIdentity userIdentity;
+  private final UserRepository userRepository;
+  private final UserGroupRepository userGroupRepository;
+
+  public UserGroupAdminEndpoint(
+      UserGroupAdminRepository userGroupAdminRepository,
+      UserIdentity userIdentity,
+      UserRepository userRepository,
+      UserGroupRepository userGroupRepository) {
+    this.userGroupAdminRepository = userGroupAdminRepository;
+    this.userIdentity = userIdentity;
+    this.userRepository = userRepository;
+    this.userGroupRepository = userGroupRepository;
+  }
+
+  @GetMapping("/findByGroup/{groupId}")
+  public List<UserGroupAdminDto> findByGroup(
+      @PathVariable(value = "groupId") UUID groupId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    return userGroupAdminRepository.findByGroupId(groupId).stream()
+        .map(
+            admin -> {
+              UserGroupAdminDto userGroupAdminDto = new UserGroupAdminDto();
+              userGroupAdminDto.setId(admin.getId());
+              userGroupAdminDto.setGroupId(admin.getGroup().getId());
+              userGroupAdminDto.setUserId(admin.getUser().getId());
+              userGroupAdminDto.setUserEmail(admin.getUser().getEmail());
+              return userGroupAdminDto;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> addUserToGroupAdmins(
+      @RequestBody UserGroupAdminDto userGroupAdminDto,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    User user =
+        userRepository
+            .findById(userGroupAdminDto.getUserId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
+
+    UserGroup group =
+        userGroupRepository
+            .findById(userGroupAdminDto.getGroupId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    UserGroupAdmin userGroupAdmin = new UserGroupAdmin();
+    userGroupAdmin.setId(UUID.randomUUID());
+    userGroupAdmin.setUser(user);
+    userGroupAdmin.setGroup(group);
+
+    userGroupAdminRepository.saveAndFlush(userGroupAdmin);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{groupAdminId}")
+  public void removeAdminFromGroup(
+      @PathVariable(value = "groupAdminId") UUID groupAdminId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+
+    userGroupAdminRepository.deleteById(groupAdminId);
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupAdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupAdminEndpoint.java
@@ -80,6 +80,11 @@ public class UserGroupAdminEndpoint {
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
+    if (user.getAdminOf().stream().anyMatch(userGroupAdmin -> userGroupAdmin.getGroup() == group)) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "User is already an admin of this group");
+    }
+
     UserGroupAdmin userGroupAdmin = new UserGroupAdmin();
     userGroupAdmin.setId(UUID.randomUUID());
     userGroupAdmin.setUser(user);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
@@ -57,15 +57,28 @@ public class UserGroupMemberEndpoint {
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
 
     return userGroupMemberRepository.findByUser(user).stream()
-        .map(
-            member -> {
-              UserGroupMemberDto userGroupMemberDto = new UserGroupMemberDto();
-              userGroupMemberDto.setId(member.getId());
-              userGroupMemberDto.setGroupId(member.getGroup().getId());
-              userGroupMemberDto.setUserId(userId);
-              userGroupMemberDto.setGroupName(member.getGroup().getName());
-              return userGroupMemberDto;
-            })
+        .map(this::mapGroupMember)
+        .collect(Collectors.toList());
+  }
+
+  @GetMapping("/findByGroup/{groupId}")
+  public List<UserGroupMemberDto> findByGroup(
+      @PathVariable(value = "groupId") UUID groupId,
+      @Value("#{request.getAttribute('userEmail')}") String userEmail) {
+    UserGroup group =
+        userGroupRepository
+            .findById(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    if (group.getAdmins().stream()
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+      // If you're not admin of this group, you have to be super user
+      userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+    }
+
+    return userGroupMemberRepository.findByGroup(group).stream()
+        .map(this::mapGroupMember)
         .collect(Collectors.toList());
   }
 
@@ -73,19 +86,23 @@ public class UserGroupMemberEndpoint {
   public ResponseEntity<Void> addUserToGroup(
       @RequestBody UserGroupMemberDto userGroupMemberDto,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+    UserGroup group =
+        userGroupRepository
+            .findById(userGroupMemberDto.getGroupId())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
+
+    if (group.getAdmins().stream()
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+      // If you're not admin of this group, you have to be super user
+      userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+    }
 
     User user =
         userRepository
             .findById(userGroupMemberDto.getUserId())
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found"));
-
-    UserGroup group =
-        userGroupRepository
-            .findById(userGroupMemberDto.getGroupId())
-            .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
     UserGroupMember userGroupMember = new UserGroupMember();
     userGroupMember.setId(UUID.randomUUID());
@@ -101,8 +118,30 @@ public class UserGroupMemberEndpoint {
   public void removeUserFromGroup(
       @PathVariable(value = "groupMemberId") UUID groupMemberId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+    UserGroupMember userGroupMember =
+        userGroupMemberRepository
+            .findById(groupMemberId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "Group membership not found"));
 
-    userGroupMemberRepository.deleteById(groupMemberId);
+    if (userGroupMember.getGroup().getAdmins().stream()
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+      // If you're not admin of this group, you have to be super user
+      userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
+    }
+
+    userGroupMemberRepository.delete(userGroupMember);
+  }
+
+  private UserGroupMemberDto mapGroupMember(UserGroupMember member) {
+    UserGroupMemberDto userGroupMemberDto = new UserGroupMemberDto();
+    userGroupMemberDto.setId(member.getId());
+    userGroupMemberDto.setGroupId(member.getGroup().getId());
+    userGroupMemberDto.setUserId(member.getUser().getId());
+    userGroupMemberDto.setUserEmail(member.getUser().getEmail());
+    userGroupMemberDto.setGroupName(member.getGroup().getName());
+    return userGroupMemberDto;
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupAdminDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/UserGroupAdminDto.java
@@ -4,10 +4,9 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-public class UserGroupMemberDto {
+public class UserGroupAdminDto {
   private UUID id;
   private UUID userId;
   private String userEmail;
   private UUID groupId;
-  private String groupName;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupAdminRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupAdminRepository.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ssdc.supporttool.model.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.ssdc.common.model.entity.UserGroupAdmin;
+
+public interface UserGroupAdminRepository extends JpaRepository<UserGroupAdmin, UUID> {
+  List<UserGroupAdmin> findByUserEmail(String email);
+
+  List<UserGroupAdmin> findByGroupId(UUID groupId);
+
+  boolean existsByUserEmail(String email);
+}

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupMemberRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupMemberRepository.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.User;
+import uk.gov.ons.ssdc.common.model.entity.UserGroup;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupMember;
 
 public interface UserGroupMemberRepository extends JpaRepository<UserGroupMember, UUID> {
   List<UserGroupMember> findByUser(User user);
+
+  List<UserGroupMember> findByGroup(UserGroup group);
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -343,7 +343,7 @@ public class AllEndpointsIT {
         (bundle) -> "userGroupAdmins",
         (bundle) -> {
           UserGroupAdminDto userGroupAdminDto = new UserGroupAdminDto();
-          userGroupAdminDto.setGroupId(bundle.getGroupId());
+          userGroupAdminDto.setGroupId(bundle.getSecondGroupId());
           userGroupAdminDto.setUserId(bundle.getUserId());
           return userGroupAdminDto;
         });

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -20,6 +20,7 @@ import uk.gov.ons.ssdc.supporttool.model.dto.ui.PrintTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.SurveyDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserDto;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupAdminDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupMemberDto;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.UserGroupPermissionDto;
@@ -330,6 +331,30 @@ public class AllEndpointsIT {
   }
 
   @Test
+  public void testUserGroupAdminEndpoints() {
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroupAdmins/findByGroup/%s", bundle.getGroupId()));
+
+    integrationTestHelper.testPost(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> "userGroupAdmins",
+        (bundle) -> {
+          UserGroupAdminDto userGroupAdminDto = new UserGroupAdminDto();
+          userGroupAdminDto.setGroupId(bundle.getGroupId());
+          userGroupAdminDto.setUserId(bundle.getUserId());
+          return userGroupAdminDto;
+        });
+
+    integrationTestHelper.testDelete(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroupAdmins/%s", bundle.getGroupAdminId()));
+  }
+
+  @Test
   public void testUserGroupEndpoints() {
     integrationTestHelper.testGet(
         port,
@@ -338,6 +363,8 @@ public class AllEndpointsIT {
 
     integrationTestHelper.testGet(
         port, UserGroupAuthorisedActivityType.SUPER_USER, (bundle) -> "userGroups");
+
+    integrationTestHelper.testGet(port, null, (bundle) -> "userGroups/thisUserAdminGroups");
 
     integrationTestHelper.testPost(
         port,
@@ -367,6 +394,11 @@ public class AllEndpointsIT {
           userGroupMemberDto.setGroupId(bundle.getSecondGroupId());
           return userGroupMemberDto;
         });
+
+    integrationTestHelper.testGet(
+        port,
+        UserGroupAuthorisedActivityType.SUPER_USER,
+        (bundle) -> String.format("userGroupMembers/findByGroup/%s", bundle.getGroupId()));
 
     integrationTestHelper.testDelete(
         port,

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/BundleOfUsefulTestStuff.java
@@ -14,6 +14,7 @@ public class BundleOfUsefulTestStuff {
   private UUID userId;
   private UUID groupId;
   private UUID groupMemberId;
+  private UUID groupAdminId;
   private UUID groupPermissionId;
   private UUID secondGroupId;
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -213,6 +213,7 @@ public class IntegrationTestHelper {
   private void restoreDummyUserAndOtherGubbins(BundleOfUsefulTestStuff bundle) {
     User user = setupDummyUser(bundle.getUserId());
     UserGroup group = setupDummyGroup(bundle.getGroupId());
+    setupDummyGroup(bundle.getSecondGroupId());
     setupDummyGroupMember(bundle.getGroupMemberId(), user, group);
     setupDummyGroupPermission(bundle.getGroupPermissionId(), group);
   }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1906,6 +1906,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.60",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz",
+      "integrity": "sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "@fontsource/roboto": "^4.2.3",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -8,6 +8,8 @@ import UserAdmin from "./UserAdmin";
 import UserDetails from "./UserDetails";
 import GroupDetails from "./GroupDetails";
 import ExceptionManager from "./ExceptionManager";
+import MyGroupsAdmin from "./MyGroupsAdmin";
+import MyGroupUserAdmin from "./MyGroupUserAdmin";
 import {
   BrowserRouter as Router,
   Switch,
@@ -73,6 +75,12 @@ function QueryRouting() {
       </Route>
       <Route path="/exceptionManager">
         <ExceptionManager />
+      </Route>
+      <Route path="/myGroupsAdmin">
+        <MyGroupsAdmin />
+      </Route>
+      <Route path="/myGroupUserAdmin">
+        <MyGroupUserAdmin groupId={query.get("groupId")} />
       </Route>
     </Switch>
   );

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -128,16 +128,14 @@ class GroupDetails extends Component {
   filterAllUsers = (allUsers, groupAdmins) => {
     const allUsersAutocompleteOptions = allUsers.filter(
       (user) =>
-        !groupAdmins
-          .map((groupAdmin) => groupAdmin.userId)
-          .includes(user.id)
+        !groupAdmins.map((groupAdmin) => groupAdmin.userId).includes(user.id)
     );
 
     this.setState({
       allUsersAutocompleteOptions: allUsersAutocompleteOptions,
     });
   };
-  
+
   getUserGroupPermissions = async (authorisedActivities) => {
     if (!authorisedActivities.includes("SUPER_USER")) return;
 
@@ -372,7 +370,7 @@ class GroupDetails extends Component {
       newAdminUserId: newValue ? newValue.id : null,
       newAdminEmailValidationError: newValue ? false : true,
     });
-  }
+  };
 
   buildSurveyMenuItem = (survey) => {
     if (survey === null) {

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -117,7 +117,7 @@ class GroupDetails extends Component {
 
     // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
     if (!response.ok) {
-      return;
+      return [];
     }
 
     const responseJson = await response.json();

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -67,7 +67,7 @@ class GroupDetails extends Component {
     this.getAllActivities();
     this.getAllSurveys(authorisedActivities);
     this.getUserGroupPermissions(authorisedActivities);
-    const allUsers = await this.getAllUsers(authorisedActivities);
+    const allUsers = await this.getAllUsers(authorisedActivities); // Only need to do this once... it's an expensive operation
     this.filterAllUsers(allUsers, admins);
 
     this.interval = setInterval(

--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogContentText,
   DialogActions,
+  TextField,
 } from "@material-ui/core";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -20,15 +21,18 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import Autocomplete from "@material-ui/lab/Autocomplete";
 
 class GroupDetails extends Component {
   state = {
     authorisedActivities: [],
     isLoading: true,
     group: {},
+    admins: [],
     groupActivities: [],
     allActivities: [],
     allSurveys: [],
+    allUsersAutocompleteOptions: [],
     showAllowDialog: false,
     showRemoveDialog: false,
     activity: null,
@@ -36,6 +40,11 @@ class GroupDetails extends Component {
     surveyId: null,
     surveyName: null,
     userGroupPermissionId: null,
+    adminIdToRemove: null,
+    showRemoveAdminDialog: false,
+    showAddAdminToGroupDialog: false,
+    newAdminUserId: "",
+    newAdminEmailValidationError: false,
   };
 
   componentDidMount() {
@@ -49,14 +58,21 @@ class GroupDetails extends Component {
   getAuthorisedBackendData = async () => {
     const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     this.getGroup(authorisedActivities);
+    this.getAdmins(authorisedActivities);
     this.getAllActivities();
     this.getAllSurveys(authorisedActivities);
     this.getUserGroupPermissions(authorisedActivities);
+    this.getAllUsers(authorisedActivities);
 
     this.interval = setInterval(
-      () => this.getUserGroupPermissions(authorisedActivities),
+      () => this.refreshBackendData(authorisedActivities),
       1000
     );
+  };
+
+  refreshBackendData = (authorisedActivities) => {
+    this.getUserGroupPermissions(authorisedActivities);
+    this.getAdmins(authorisedActivities);
   };
 
   getGroup = async (authorisedActivities) => {
@@ -69,6 +85,35 @@ class GroupDetails extends Component {
     this.setState({
       group: groupJson,
     });
+  };
+
+  getAdmins = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
+    const response = await fetch(
+      `/api/userGroupAdmins/findByGroup/${this.props.groupId}`
+    );
+
+    const responseJson = await response.json();
+
+    this.setState({
+      admins: responseJson,
+    });
+  };
+
+  getAllUsers = async (authorisedActivities) => {
+    if (!authorisedActivities.includes("SUPER_USER")) return;
+
+    const response = await fetch("/api/users");
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const responseJson = await response.json();
+
+    this.setState({ allUsersAutocompleteOptions: responseJson });
   };
 
   getUserGroupPermissions = async (authorisedActivities) => {
@@ -199,7 +244,93 @@ class GroupDetails extends Component {
     this.setState({ showAllowDialog: false });
   };
 
+  openRemoveAdminDialog = (adminIdToRemove) => {
+    this.setState({
+      adminIdToRemove: adminIdToRemove,
+      showRemoveAdminDialog: true,
+    });
+  };
+
+  removeAdmin = async () => {
+    const response = await fetch(
+      `/api/userGroupAdmins/${this.state.adminIdToRemove}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (response.ok) {
+      this.closeRemoveAdminDialog();
+    }
+  };
+
+  closeRemoveAdminDialog = () => {
+    this.setState({
+      adminIdToRemove: null,
+      showRemoveAdminDialog: false,
+    });
+  };
+
+  openAddAdminUserDialog = () => {
+    this.setState({
+      newAdminUserId: null,
+      newAdminEmailValidationError: false,
+      showAddAdminToGroupDialog: true,
+    });
+  };
+
+  onAddAdmin = async () => {
+    if (!this.state.newAdminUserId) {
+      this.setState({ newAdminEmailValidationError: true });
+      return;
+    }
+
+    const newGroupAdmin = {
+      userId: this.state.newAdminUserId,
+      groupId: this.props.groupId,
+    };
+
+    const response = await fetch("/api/userGroupAdmins", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newGroupAdmin),
+    });
+
+    if (response.ok) {
+      this.closeAddAdminDialog();
+    }
+  };
+
+  closeAddAdminDialog = () => {
+    this.setState({
+      showAddAdminToGroupDialog: false,
+    });
+  };
+
+  onNewAdminEmailChange = (_, newValue) => {
+    this.setState({
+      newAdminUserId: newValue ? newValue.id : null,
+      newAdminEmailValidationError: newValue ? false : true,
+    });
+  };
+
   render() {
+    const adminsTableRows = this.state.admins.map((admin) => (
+      <TableRow key={admin.id}>
+        <TableCell component="th" scope="row">
+          {admin.userEmail}
+        </TableCell>
+        <TableCell component="th" scope="row">
+          <Button
+            variant="contained"
+            onClick={() => this.openRemoveAdminDialog(admin.id)}
+          >
+            Remove
+          </Button>
+        </TableCell>
+      </TableRow>
+    ));
+
     const groupActivitiesTableRows = this.state.groupActivities.map(
       (groupActivity, index) => {
         const surveyName = groupActivity.surveyId
@@ -250,23 +381,42 @@ class GroupDetails extends Component {
     return (
       <div style={{ padding: 20 }}>
         <Link to="/userAdmin">← Back to admin</Link>
-        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
+        <Typography variant="h4" color="inherit">
           Group Details: {this.state.group.name}
         </Typography>
         {!this.state.authorisedActivities.includes("SUPER_USER") &&
           !this.state.isLoading && (
-            <h1 style={{ color: "red" }}>YOU ARE NOT AUTHORISED</h1>
+            <h1 style={{ color: "red", marginTop: 20 }}>
+              YOU ARE NOT AUTHORISED
+            </h1>
           )}
         {this.state.authorisedActivities.includes("SUPER_USER") && (
           <>
+            <Typography variant="h6" color="inherit">
+              Admins
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Email</TableCell>
+                    <TableCell>Action</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{adminsTableRows}</TableBody>
+              </Table>
+            </TableContainer>
             <Button
               variant="contained"
-              onClick={this.openAllowDialog}
-              style={{ marginTop: 20 }}
+              onClick={this.openAddAdminUserDialog}
+              style={{ marginTop: 10 }}
             >
-              Allow Activity
+              Add Admin User
             </Button>
-            <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 10 }}>
+              Allowed Activities
+            </Typography>
+            <TableContainer component={Paper}>
               <Table>
                 <TableHead>
                   <TableRow>
@@ -278,6 +428,13 @@ class GroupDetails extends Component {
                 <TableBody>{groupActivitiesTableRows}</TableBody>
               </Table>
             </TableContainer>
+            <Button
+              variant="contained"
+              onClick={this.openAllowDialog}
+              style={{ marginTop: 10 }}
+            >
+              Allow Activity
+            </Button>
             <Dialog open={this.state.showAllowDialog}>
               <DialogContent
                 style={{ paddingLeft: 30, paddingRight: 30, paddingBottom: 10 }}
@@ -337,6 +494,65 @@ class GroupDetails extends Component {
                 </Button>
                 <Button
                   onClick={this.closeRemoveDialog}
+                  color="primary"
+                  autoFocus
+                >
+                  No
+                </Button>
+              </DialogActions>
+            </Dialog>
+            <Dialog open={this.state.showAddAdminToGroupDialog}>
+              <DialogContent
+                style={{ paddingLeft: 30, paddingRight: 30, paddingBottom: 10 }}
+              >
+                <div>
+                  <Autocomplete
+                    options={this.state.allUsersAutocompleteOptions}
+                    getOptionLabel={(option) => option.email}
+                    onChange={this.onNewAdminEmailChange}
+                    renderInput={(params) => (
+                      <TextField
+                        required
+                        {...params}
+                        error={this.state.newAdminEmailValidationError}
+                        label="Email"
+                      />
+                    )}
+                  />{" "}
+                </div>
+                <div style={{ marginTop: 10 }}>
+                  <Button
+                    onClick={this.onAddAdmin}
+                    variant="contained"
+                    style={{ margin: 10 }}
+                  >
+                    Add Admin
+                  </Button>
+                  <Button
+                    onClick={this.closeAddAdminDialog}
+                    variant="contained"
+                    style={{ margin: 10 }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
+            <Dialog open={this.state.showRemoveAdminDialog}>
+              <DialogTitle id="alert-dialog-title">
+                {"Confirm remove admin"}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  Are you sure you wish to remove group admin?
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.removeAdmin} color="primary">
+                  Yes
+                </Button>
+                <Button
+                  onClick={this.closeRemoveAdminDialog}
                   color="primary"
                   autoFocus
                 >

--- a/ui/src/LandingPage.js
+++ b/ui/src/LandingPage.js
@@ -23,6 +23,7 @@ import { Link } from "react-router-dom";
 class LandingPage extends Component {
   state = {
     authorisedActivities: [],
+    thisUserAdminGroups: [],
     surveys: [],
     createSurveyDialogDisplayed: false,
     validationError: false,
@@ -63,6 +64,7 @@ class LandingPage extends Component {
   }
 
   getAuthorisedBackendData = async () => {
+    this.getThisUserAdminGroups(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     const authorisedActivities = await this.getAuthorisedActivities(); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
     this.getPrintSuppliers(authorisedActivities); // Only need to do this once; don't refresh it repeatedly as it changes infrequently
 
@@ -87,6 +89,19 @@ class LandingPage extends Component {
     this.setState({ authorisedActivities: authorisedActivities });
 
     return authorisedActivities;
+  };
+
+  getThisUserAdminGroups = async () => {
+    const response = await fetch("/api/userGroups/thisUserAdminGroups");
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const responseJson = await response.json();
+
+    this.setState({ thisUserAdminGroups: responseJson });
   };
 
   refreshDataFromBackend = (authorisedActivities) => {
@@ -666,6 +681,13 @@ class LandingPage extends Component {
           <>
             <div style={{ marginTop: 20 }}>
               <Link to="/userAdmin">User and Groups Admin</Link>
+            </div>
+          </>
+        )}
+        {this.state.thisUserAdminGroups.length > 0 && (
+          <>
+            <div style={{ marginTop: 20 }}>
+              <Link to="/myGroupsAdmin">My Groups Admin</Link>
             </div>
           </>
         )}

--- a/ui/src/MyGroupUserAdmin.js
+++ b/ui/src/MyGroupUserAdmin.js
@@ -1,0 +1,252 @@
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
+import {
+  Typography,
+  Paper,
+  Button,
+  Dialog,
+  DialogContent,
+  TextField,
+  DialogTitle,
+  DialogContentText,
+  DialogActions,
+} from "@material-ui/core";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+
+class MyGroupUserAdmin extends Component {
+  state = {
+    groupName: "",
+    groupMembers: [],
+    showAddUserToGroupDialog: false,
+    allUsersAutocompleteOptions: [],
+    userId: "",
+    emailValidationError: false,
+    showRemoveDialog: false,
+    groupMemberIdToRemove: null,
+  };
+
+  componentDidMount() {
+    this.getAuthorisedBackendData();
+
+    this.interval = setInterval(() => this.getGroupMembers(), 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  getAuthorisedBackendData = async () => {
+    this.getGroup();
+    this.getGroupMembers();
+    this.getAllUsers();
+  };
+
+  getGroup = async () => {
+    const response = await fetch(`/api/userGroups/${this.props.groupId}`);
+
+    const responseJson = await response.json();
+
+    this.setState({ groupName: responseJson.name });
+  };
+
+  getGroupMembers = async () => {
+    const response = await fetch(
+      `/api/userGroupMembers/findByGroup/${this.props.groupId}`
+    );
+
+    const responseJson = await response.json();
+
+    this.setState({
+      groupMembers: responseJson,
+    });
+  };
+
+  getAllUsers = async () => {
+    const response = await fetch("/api/users");
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return;
+    }
+
+    const responseJson = await response.json();
+
+    this.setState({ allUsersAutocompleteOptions: responseJson });
+  };
+
+  onEmailChange = (_, newValue) => {
+    this.setState({
+      userId: newValue ? newValue.id : null,
+      emailValidationError: newValue ? false : true,
+    });
+  };
+
+  openAddUserDialog = () => {
+    this.setState({
+      showAddUserToGroupDialog: true,
+      userId: "",
+      emailValidationError: false,
+    });
+  };
+
+  closeAddUserDialog = () => {
+    this.setState({
+      showAddUserToGroupDialog: false,
+    });
+  };
+
+  onAddUser = async () => {
+    if (!this.state.userId) {
+      this.setState({ emailValidationError: true });
+      return;
+    }
+
+    const newGroupMembership = {
+      userId: this.state.userId,
+      groupId: this.props.groupId,
+    };
+
+    const response = await fetch("/api/userGroupMembers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newGroupMembership),
+    });
+
+    if (response.ok) {
+      this.setState({ showAddUserToGroupDialog: false });
+    }
+  };
+
+  openRemoveDialog = (groupMemberIdToRemove) => {
+    this.setState({
+      groupMemberIdToRemove: groupMemberIdToRemove,
+      showRemoveDialog: true,
+    });
+  };
+
+  closeRemoveDialog = () => {
+    this.setState({
+      groupMemberIdToRemove: null,
+      showRemoveDialog: false,
+    });
+  };
+
+  removeUserFromGroup = async () => {
+    const response = await fetch(
+      `/api/userGroupMembers/${this.state.groupMemberIdToRemove}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (response.ok) {
+      this.closeRemoveDialog();
+    }
+  };
+
+  render() {
+    const usersTableRows = this.state.groupMembers.map((groupMember) => (
+      <TableRow key={groupMember.id}>
+        <TableCell component="th" scope="row">
+          {groupMember.userEmail}
+        </TableCell>
+        <TableCell component="th" scope="row">
+          <Button
+            variant="contained"
+            onClick={() => this.openRemoveDialog(groupMember.id)}
+          >
+            Remove
+          </Button>
+        </TableCell>
+      </TableRow>
+    ));
+
+    return (
+      <div style={{ padding: 20 }}>
+        <Link to="/myGroupsAdmin">← Back to my groups</Link>
+        <Typography variant="h4" color="inherit">
+          My Group: {this.state.groupName}
+        </Typography>
+        <TableContainer component={Paper} style={{ marginTop: 10 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Email</TableCell>
+                <TableCell>Action</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>{usersTableRows}</TableBody>
+          </Table>
+        </TableContainer>
+        <Button
+          variant="contained"
+          onClick={this.openAddUserDialog}
+          style={{ marginTop: 20 }}
+        >
+          Add User to Group
+        </Button>
+        <Dialog open={this.state.showAddUserToGroupDialog}>
+          <DialogContent
+            style={{ paddingLeft: 30, paddingRight: 30, paddingBottom: 10 }}
+          >
+            <div>
+              <Autocomplete
+                options={this.state.allUsersAutocompleteOptions}
+                getOptionLabel={(option) => option.email}
+                onChange={this.onEmailChange}
+                renderInput={(params) => (
+                  <TextField
+                    required
+                    {...params}
+                    error={this.state.emailValidationError}
+                    label="Email"
+                  />
+                )}
+              />{" "}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <Button
+                onClick={this.onAddUser}
+                variant="contained"
+                style={{ margin: 10 }}
+              >
+                Add User to Group
+              </Button>
+              <Button
+                onClick={this.closeAddUserDialog}
+                variant="contained"
+                style={{ margin: 10 }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={this.state.showRemoveDialog}>
+          <DialogTitle id="alert-dialog-title">{"Confirm remove?"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              Are you sure you wish to remove user from group?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.removeUserFromGroup} color="primary">
+              Yes
+            </Button>
+            <Button onClick={this.closeRemoveDialog} color="primary" autoFocus>
+              No
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+export default MyGroupUserAdmin;

--- a/ui/src/MyGroupUserAdmin.js
+++ b/ui/src/MyGroupUserAdmin.js
@@ -38,7 +38,7 @@ class MyGroupUserAdmin extends Component {
     this.refreshBackendData(allUsers);
 
     this.interval = setInterval(() => this.refreshBackendData(allUsers), 1000);
-  }
+  };
 
   componentWillUnmount() {
     clearInterval(this.interval);

--- a/ui/src/MyGroupsAdmin.js
+++ b/ui/src/MyGroupsAdmin.js
@@ -1,0 +1,78 @@
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
+import { Typography, Paper } from "@material-ui/core";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+
+class MyGroupsAdmin extends Component {
+  state = {
+    thisUserAdminGroups: [],
+    isLoading: true,
+  };
+
+  componentDidMount() {
+    this.getThisUserAdminGroups();
+  }
+
+  getThisUserAdminGroups = async () => {
+    const response = await fetch("/api/userGroups/thisUserAdminGroups");
+
+    // TODO: We need more elegant error handling throughout the whole application, but this will at least protect temporarily
+    if (!response.ok) {
+      return [];
+    }
+
+    const responseJson = await response.json();
+
+    this.setState({ thisUserAdminGroups: responseJson, isLoading: false });
+  };
+
+  render() {
+    const groupsTableRows = this.state.thisUserAdminGroups.map((group) => {
+      return (
+        <TableRow key={group.id}>
+          <TableCell component="th" scope="row">
+            <Link to={`/myGroupUserAdmin?groupId=${group.id}`}>
+              {group.name}
+            </Link>
+          </TableCell>
+        </TableRow>
+      );
+    });
+
+    return (
+      <div style={{ padding: 20 }}>
+        <Link to="/">← Back to home</Link>
+        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
+          My Groups Admin
+        </Typography>
+        {this.state.thisUserAdminGroups.length === 0 &&
+          !this.state.isLoading && (
+            <h1 style={{ color: "red" }}>YOU ARE NOT AUTHORISED</h1>
+          )}
+        {this.state.thisUserAdminGroups.length > 0 && (
+          <>
+            <>
+              <TableContainer component={Paper} style={{ marginTop: 20 }}>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Name</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>{groupsTableRows}</TableBody>
+                </Table>
+              </TableContainer>
+            </>
+          </>
+        )}
+      </div>
+    );
+  }
+}
+
+export default MyGroupsAdmin;

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -193,24 +193,22 @@ class UserAdmin extends Component {
     return (
       <div style={{ padding: 20 }}>
         <Link to="/">← Back to home</Link>
-        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
+        <Typography variant="h4" color="inherit">
           User Admin
         </Typography>
         {!this.state.authorisedActivities.includes("SUPER_USER") &&
           !this.state.isLoading && (
-            <h1 style={{ color: "red" }}>YOU ARE NOT AUTHORISED</h1>
+            <h1 style={{ color: "red", marginTop: 20 }}>
+              YOU ARE NOT AUTHORISED
+            </h1>
           )}
         {this.state.authorisedActivities.includes("SUPER_USER") && (
           <>
             <>
-              <Button
-                variant="contained"
-                onClick={this.openCreateUserDialog}
-                style={{ marginTop: 20 }}
-              >
-                Create User
-              </Button>
-              <TableContainer component={Paper} style={{ marginTop: 20 }}>
+              <Typography variant="h6" color="inherit">
+                Users
+              </Typography>
+              <TableContainer component={Paper}>
                 <Table>
                   <TableHead>
                     <TableRow>
@@ -220,16 +218,23 @@ class UserAdmin extends Component {
                   <TableBody>{usersTableRows}</TableBody>
                 </Table>
               </TableContainer>
-            </>
-            <>
               <Button
                 variant="contained"
-                onClick={this.openCreateGroupDialog}
-                style={{ marginTop: 20 }}
+                onClick={this.openCreateUserDialog}
+                style={{ marginTop: 10 }}
               >
-                Create Group
+                Create User
               </Button>
-              <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            </>
+            <>
+              <Typography
+                variant="h6"
+                color="inherit"
+                style={{ marginTop: 10 }}
+              >
+                Groups
+              </Typography>
+              <TableContainer component={Paper}>
                 <Table>
                   <TableHead>
                     <TableRow>
@@ -239,6 +244,13 @@ class UserAdmin extends Component {
                   <TableBody>{groupsTableRows}</TableBody>
                 </Table>
               </TableContainer>
+              <Button
+                variant="contained"
+                onClick={this.openCreateGroupDialog}
+                style={{ marginTop: 10 }}
+              >
+                Create Group
+              </Button>
             </>
           </>
         )}

--- a/ui/src/UserDetails.js
+++ b/ui/src/UserDetails.js
@@ -212,23 +212,21 @@ class UserDetails extends Component {
     return (
       <div style={{ padding: 20 }}>
         <Link to="/userAdmin">← Back to admin</Link>
-        <Typography variant="h4" color="inherit" style={{ marginBottom: 20 }}>
+        <Typography variant="h4" color="inherit">
           User Details: {this.state.user.email}
         </Typography>
         {!this.state.authorisedActivities.includes("SUPER_USER") &&
           !this.state.isLoading && (
-            <h1 style={{ color: "red" }}>YOU ARE NOT AUTHORISED</h1>
+            <h1 style={{ color: "red", marginTop: 20 }}>
+              YOU ARE NOT AUTHORISED
+            </h1>
           )}
         {this.state.authorisedActivities.includes("SUPER_USER") && (
           <>
-            <Button
-              variant="contained"
-              onClick={this.openJoinGroupDialog}
-              style={{ marginTop: 20 }}
-            >
-              Add User to Group
-            </Button>
-            <TableContainer component={Paper} style={{ marginTop: 20 }}>
+            <Typography variant="h6" color="inherit">
+              Groups
+            </Typography>
+            <TableContainer component={Paper}>
               <Table>
                 <TableHead>
                   <TableRow>
@@ -239,6 +237,13 @@ class UserDetails extends Component {
                 <TableBody>{memberOfGroupTableRows}</TableBody>
               </Table>
             </TableContainer>
+            <Button
+              variant="contained"
+              onClick={this.openJoinGroupDialog}
+              style={{ marginTop: 10 }}
+            >
+              Add User to Group
+            </Button>
             <Dialog open={this.state.showGroupDialog}>
               <DialogContent
                 style={{ paddingLeft: 30, paddingRight: 30, paddingBottom: 10 }}


### PR DESCRIPTION
# Motivation and Context
Only allowing super users to administer users is not a good security model

# What has changed
Users can be made "group admin" (by a super user) which allows them to add and remove users from the group that they are admin of.

# How to test?
Try it!

# Links
Trello: https://trello.com/c/wOVQ3NxV

# Screenshots (if appropriate):
<img width="1114" alt="Screenshot 2021-10-13 at 16 35 40" src="https://user-images.githubusercontent.com/41681172/137167097-f8f2fd41-2903-4047-aa40-a04f23f6f4ac.png">
<img width="492" alt="Screenshot 2021-10-13 at 16 37 35" src="https://user-images.githubusercontent.com/41681172/137167106-74aadabd-7e77-4be1-8064-48d2d499f0ab.png">
<img width="427" alt="Screenshot 2021-10-13 at 16 37 28" src="https://user-images.githubusercontent.com/41681172/137167109-434c94fa-2b9a-4840-bf86-8e1772ab070b.png">
<img width="1111" alt="Screenshot 2021-10-13 at 16 37 07" src="https://user-images.githubusercontent.com/41681172/137167112-214d4f14-6084-4ea9-9bc1-7ae611c06cdd.png">
<img width="1109" alt="Screenshot 2021-10-13 at 16 36 57" src="https://user-images.githubusercontent.com/41681172/137167119-f52cca6a-30b9-414e-baa4-9d991c32a57d.png">
<img width="543" alt="Screenshot 2021-10-13 at 16 36 44" src="https://user-images.githubusercontent.com/41681172/137167121-b861ce60-3cc5-458b-9c91-cb0cb76076f1.png">
<img width="1112" alt="Screenshot 2021-10-13 at 16 36 26" src="https://user-images.githubusercontent.com/41681172/137167123-b040c215-52c5-4784-95df-183785a4813f.png">
<img width="1111" alt="Screenshot 2021-10-13 at 16 36 01" src="https://user-images.githubusercontent.com/41681172/137167126-7be02bb4-2a2c-4ece-a10d-e9b548392060.png">
