### PR TITLE
Remove ability for group admins to list all groups

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
@@ -59,10 +59,7 @@ public class UserGroupEndpoint {
   @GetMapping
   public List<UserGroupDto> getUserGroups(
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    if (!userGroupAdminRepository.existsByUserEmail(userEmail)) {
-      // If you're not admin of a group, you have to be super user
-      userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
-    }
+    userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
 
     return userGroupRepository.findAll().stream().map(this::mapDto).collect(Collectors.toList());
   }


### PR DESCRIPTION
# Motivation and Context
There is no need for group admins to be able to list ALL groups. They should only be able to see groups that they are an admin of.

# What has changed
Removed permission for group admins to be able to list groups.

# How to test?
Try calling the `/api/userGroups` endpoint as a group admin, but with no other permissions. It should respond with `403 FORBIDDEN`.

# Links
Trello: https://trello.com/c/xLxQg2oP