### PR TITLE
Remove superflous Ands from JobRowRepository

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -107,7 +107,7 @@ public class JobEndpoint {
         userEmail, job.getCollectionExercise().getSurvey(), LOAD_SAMPLE);
 
     List<JobRow> jobRows =
-        jobRowRepository.findByJobAndAndJobRowStatusOrderByOriginalRowLineNumber(
+        jobRowRepository.findByJobAndJobRowStatusOrderByOriginalRowLineNumber(
             job, JobRowStatus.VALIDATED_ERROR);
 
     String csvFileName = "ERROR_" + job.getFileName();
@@ -147,7 +147,7 @@ public class JobEndpoint {
         userEmail, job.getCollectionExercise().getSurvey(), LOAD_SAMPLE);
 
     List<JobRow> jobRows =
-        jobRowRepository.findByJobAndAndJobRowStatusOrderByOriginalRowLineNumber(
+        jobRowRepository.findByJobAndJobRowStatusOrderByOriginalRowLineNumber(
             job, JobRowStatus.VALIDATED_ERROR);
 
     String csvFileName = "ERROR_DETAIL_" + job.getFileName();
@@ -217,7 +217,7 @@ public class JobEndpoint {
       job.setCancelledAt(OffsetDateTime.now());
       jobRepository.saveAndFlush(job);
 
-      jobRowRepository.deleteByJobAndAndJobRowStatus(job, JobRowStatus.VALIDATED_OK);
+      jobRowRepository.deleteByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_OK);
     } else {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Can't cancel a job which isn't validated");

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/JobRowRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/JobRowRepository.java
@@ -11,18 +11,18 @@ import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.model.entity.JobRowStatus;
 
 public interface JobRowRepository extends JpaRepository<JobRow, UUID> {
-  int countByJobAndAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
+  int countByJobAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
 
-  boolean existsByJobAndAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
+  boolean existsByJobAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
 
-  List<JobRow> findByJobAndAndJobRowStatusOrderByOriginalRowLineNumber(
+  List<JobRow> findByJobAndJobRowStatusOrderByOriginalRowLineNumber(
       Job job, JobRowStatus jobRowStatus);
 
   // This is required because otherwise Hibernate will attempt to read ALL the JobRows, which
   // could number in the millions, causing an out of memory crash
   @Modifying
   @Query("delete from JobRow r where r.job = :job and r.jobRowStatus = :rowStatus")
-  void deleteByJobAndAndJobRowStatus(
+  void deleteByJobAndJobRowStatus(
       @Param("job") Job job, @Param("rowStatus") JobRowStatus rowStatus);
 
   // This is required because otherwise Hibernate will attempt to read ALL the JobRows, which
@@ -31,5 +31,5 @@ public interface JobRowRepository extends JpaRepository<JobRow, UUID> {
   @Query("delete from JobRow r where r.job = :job")
   void deleteByJob(@Param("job") Job job);
 
-  List<JobRow> findTop500ByJobAndAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
+  List<JobRow> findTop500ByJobAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkProcessor.java
@@ -52,7 +52,7 @@ public class RowChunkProcessor {
         job.getCollectionExercise().getSurvey().getSampleValidationRules();
 
     List<JobRow> jobRows =
-        jobRowRepository.findTop500ByJobAndAndJobRowStatus(job, JobRowStatus.VALIDATED_OK);
+        jobRowRepository.findTop500ByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_OK);
 
     for (JobRow jobRow : jobRows) {
       try {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkValidator.java
@@ -30,7 +30,7 @@ public class RowChunkValidator {
         job.getCollectionExercise().getSurvey().getSampleValidationRules();
 
     List<JobRow> jobRows =
-        jobRowRepository.findTop500ByJobAndAndJobRowStatus(job, JobRowStatus.STAGED);
+        jobRowRepository.findTop500ByJobAndJobRowStatus(job, JobRowStatus.STAGED);
 
     for (JobRow jobRow : jobRows) {
       JobRowStatus rowStatus = JobRowStatus.VALIDATED_OK;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/StagedJobValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/StagedJobValidator.java
@@ -34,7 +34,7 @@ public class StagedJobValidator {
     for (Job job : jobs) {
       JobStatus jobStatus = JobStatus.VALIDATED_OK;
 
-      while (jobRowRepository.existsByJobAndAndJobRowStatus(job, JobRowStatus.STAGED)) {
+      while (jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.STAGED)) {
         if (rowChunkValidator.processChunk(job)) {
           jobStatus = JobStatus.VALIDATED_WITH_ERRORS;
         }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/ValidatedJobProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/ValidatedJobProcessor.java
@@ -35,14 +35,14 @@ public class ValidatedJobProcessor {
     List<Job> jobs = jobRepository.findByJobStatus(JobStatus.PROCESSING_IN_PROGRESS);
 
     for (Job job : jobs) {
-      while (jobRowRepository.existsByJobAndAndJobRowStatus(job, JobRowStatus.VALIDATED_OK)) {
+      while (jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_OK)) {
         rowChunkProcessor.processChunk(job);
       }
 
       job.setJobStatus(JobStatus.PROCESSED);
       jobRepository.save(job);
 
-      jobRowRepository.deleteByJobAndAndJobRowStatus(job, JobRowStatus.PROCESSED);
+      jobRowRepository.deleteByJobAndJobRowStatus(job, JobRowStatus.PROCESSED);
     }
   }
 }


### PR DESCRIPTION
# Motivation and Context
All the methods in `JobRowRepository` had `AndAnd` instead of just `And`.

# What has changed
Tidied up the code.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/Mj64FcGN