### PR TITLE
Use index as key for upload rows

### DIFF
--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -262,7 +262,7 @@ class BulkUploads extends Component {
     viewerPermission
   ) {
     const bulkJobTableRows = bulkJobs.map((job, index) => (
-      <TableRow key={job.createdAt}>
+      <TableRow key={index}>
         <TableCell component="th" scope="row">
           {job.fileName}
         </TableCell>

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -158,7 +158,7 @@ class SampleUpload extends Component {
     );
 
     const jobTableRows = this.state.jobs.map((job, index) => (
-      <TableRow key={job.createdAt}>
+      <TableRow key={index}>
         <TableCell component="th" scope="row">
           {job.fileName}
         </TableCell>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Tables were incorrectly using the upload job created date as the table key.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Tables now use index as the key.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Upload some files and check it all displays correctly
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/MGxzLrQI/3050-support-tool-ui-use-unique-index-identifier-for-table-rows-in-sample-and-bulk-uploads
# Screenshots (if appropriate):
