### PR TITLE
3075 Handle errors in string to UUID conversion in case ID rule

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/validators/CaseExistsInCollectionExerciseRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/validators/CaseExistsInCollectionExerciseRule.java
@@ -19,12 +19,18 @@ public class CaseExistsInCollectionExerciseRule implements Rule {
   @Override
   public Optional<String> checkValidity(String data) {
 
-    if (!getCaseRepository()
-        .existsByIdAndCollectionExercise(UUID.fromString(data), collectionExercise)) {
+    UUID caseId;
+    try {
+      caseId = UUID.fromString(data);
+    } catch (IllegalArgumentException e) {
+      return Optional.of(String.format("Case Id \"%s\" is not a valid UUID format", data));
+    }
+
+    if (!getCaseRepository().existsByIdAndCollectionExercise(caseId, collectionExercise)) {
       return Optional.of(
           String.format(
               "Case Id %s does not exist in collection exercise %s",
-              data, collectionExercise.getName()));
+              caseId, collectionExercise.getName()));
     }
 
     return Optional.empty();

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/validators/CaseExistsInCollectionExerciseRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/validators/CaseExistsInCollectionExerciseRuleTest.java
@@ -1,0 +1,84 @@
+package uk.gov.ons.ssdc.supporttool.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.supporttool.model.repository.CaseRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CaseExistsInCollectionExerciseRuleTest {
+
+  @Mock CaseRepository caseRepository;
+
+  @Test
+  void checkValidityValid() {
+    // Given
+    UUID caseId = UUID.randomUUID();
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    CaseExistsInCollectionExerciseRule caseExistsInCollectionExerciseRule =
+        new CaseExistsInCollectionExerciseRule(collectionExercise);
+    ReflectionTestUtils.setField(
+        caseExistsInCollectionExerciseRule, "caseRepository", caseRepository);
+    when(caseRepository.existsByIdAndCollectionExercise(caseId, collectionExercise))
+        .thenReturn(true);
+
+    // When
+    Optional<String> validitionFailure =
+        caseExistsInCollectionExerciseRule.checkValidity(caseId.toString());
+
+    // Then
+    assertThat(validitionFailure).isNotPresent();
+  }
+
+  @Test
+  void checkValidityNotValidCaseDoesNotExist() {
+    // Given
+    UUID caseId = UUID.randomUUID();
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    CaseExistsInCollectionExerciseRule caseExistsInCollectionExerciseRule =
+        new CaseExistsInCollectionExerciseRule(collectionExercise);
+    ReflectionTestUtils.setField(
+        caseExistsInCollectionExerciseRule, "caseRepository", caseRepository);
+    when(caseRepository.existsByIdAndCollectionExercise(caseId, collectionExercise))
+        .thenReturn(false);
+
+    // When
+    Optional<String> validationFailure =
+        caseExistsInCollectionExerciseRule.checkValidity(caseId.toString());
+
+    // Then
+    assertThat(validationFailure)
+        .contains(
+            String.format(
+                "Case Id %s does not exist in collection exercise %s",
+                caseId, collectionExercise.getName()));
+  }
+
+  @Test
+  void checkValidityNotValidBadFormat() {
+    // Given
+    String invalidFormatCaseId = "Not a valid UUID";
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(UUID.randomUUID());
+    CaseExistsInCollectionExerciseRule caseExistsInCollectionExerciseRule =
+        new CaseExistsInCollectionExerciseRule(collectionExercise);
+
+    // When
+    Optional<String> validationFailure =
+        caseExistsInCollectionExerciseRule.checkValidity(invalidFormatCaseId);
+
+    // Then
+    assertThat(validationFailure)
+        .contains(String.format("Case Id \"%s\" is not a valid UUID format", invalidFormatCaseId));
+  }
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The bulk processor would fail at runtime if the `CaseExistsInCollectionExerciseRule` was given an invalid format UUID.

# What has changed
- Handle errors in UUID from string in `CaseExistsInCollectionExerciseRule`
- Add tests

# How to test?
Try bulk processing a file with an invalid format case ID. It should now be reported as a standard validation failure, not cause unhandled errors.

# Links
https://trello.com/c/SiYRKz0w/3075-bulk-processor-crashes-handle-non-uuid-values-in-case-id-validator