### PR TITLE
added a second docker login command to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ jobs:
 
       before_install:
         - make format-check-mvn
-        - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+        - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}"
+        - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";;
         - docker network create ssdcrmdockerdev_default
         - echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > ~/google-service-account-key.json
         - export GOOGLE_APPLICATION_CREDENTIALS=~/google-service-account-key.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jobs:
 
       before_install:
         - make format-check-mvn
-        - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}"
-        - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";;
+        - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+        - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
         - docker network create ssdcrmdockerdev_default
         - echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > ~/google-service-account-key.json
         - export GOOGLE_APPLICATION_CREDENTIALS=~/google-service-account-key.json


### PR DESCRIPTION
# Motivation and Context
our travis builds are failing often due to dockerhub rate limiting failures, to solve this we need to log into an dockerhub enterprise account

# What has changed
- added a second docker login command line into .travis to use a enterprise dockerhub account

# How to test?
- trigger tests in travis and make sure it doesn't fail
