### PR TITLE
Collection Instrument Rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.6.0-SNAPSHOT</version>
+      <version>4.7.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
@@ -137,6 +137,8 @@ public class CollectionExerciseEndpoint {
     collectionExercise.setStartDate(collectionExerciseDto.getStartDate());
     collectionExercise.setEndDate(collectionExerciseDto.getEndDate());
     collectionExercise.setMetadata(collectionExerciseDto.getMetadata());
+    collectionExercise.setCollectionInstrumentSelectionRules(
+        collectionExerciseDto.getCollectionInstrumentSelectionRules());
     collectionExercise = collectionExerciseRepository.saveAndFlush(collectionExercise);
 
     CollectionExerciseUpdateDTO collectionExerciseUpdate = new CollectionExerciseUpdateDTO();

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/CollectionExerciseDto.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
 
 @Data
 public class CollectionExerciseDto {
@@ -13,4 +14,5 @@ public class CollectionExerciseDto {
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
   private Object metadata;
+  private CollectionInstrumentSelectionRule[] collectionInstrumentSelectionRules;
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -11,6 +11,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleType;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.common.validation.ColumnValidator;
 import uk.gov.ons.ssdc.common.validation.Rule;
@@ -237,6 +238,10 @@ class AllEndpointsIT {
           collectionExerciseDto.setStartDate(OffsetDateTime.now());
           collectionExerciseDto.setEndDate(OffsetDateTime.now().plusDays(2));
           collectionExerciseDto.setMetadata(TEST_COLLECTION_EXERCISE_UPDATE_METADATA);
+          collectionExerciseDto.setCollectionInstrumentSelectionRules(
+              new CollectionInstrumentSelectionRule[] {
+                new CollectionInstrumentSelectionRule(0, null, "dummyUrl")
+              });
           return collectionExerciseDto;
         });
   }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpointIT.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.dto.messaging.EventDTO;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.CollectionExerciseDto;
@@ -71,6 +72,10 @@ public class CollectionExerciseEndpointIT {
             collectionExerciseDto.setStartDate(collexStartDate);
             collectionExerciseDto.setEndDate(collexEndDate);
             collectionExerciseDto.setMetadata(TEST_COLLECTION_EXERCISE_UPDATE_METADATA);
+            collectionExerciseDto.setCollectionInstrumentSelectionRules(
+                new CollectionInstrumentSelectionRule[] {
+                  new CollectionInstrumentSelectionRule(0, null, "dummyUrl")
+                });
             return collectionExerciseDto;
           });
 

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpointTest.java
@@ -1,0 +1,104 @@
+package uk.gov.ons.ssdc.supporttool.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
+import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.CollectionExerciseDto;
+import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+
+@ExtendWith(MockitoExtension.class)
+public class CollectionExerciseEndpointTest {
+  @Mock SurveyRepository surveyRepository;
+  @Mock UserIdentity userIdentity; // This is required, trust me
+
+  @InjectMocks CollectionExerciseEndpoint underTest;
+
+  @Test
+  void createCollectionExercisesRejectsEmptyListOfCollectionInstrumentSelectionRules() {
+    CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+    collectionExerciseDto.setSurveyId(UUID.randomUUID());
+    collectionExerciseDto.setCollectionInstrumentSelectionRules(
+        new CollectionInstrumentSelectionRule[] {});
+
+    when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(new Survey()));
+
+    ResponseStatusException thrown =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> underTest.createCollectionExercises(collectionExerciseDto, null));
+
+    assertThat(thrown.getReason())
+        .isEqualTo("Rules must include zero priority default with null expression");
+  }
+
+  @Test
+  void createCollectionExercisesRejectsUnparseableSpelExpression() {
+    CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+    collectionExerciseDto.setSurveyId(UUID.randomUUID());
+    collectionExerciseDto.setCollectionInstrumentSelectionRules(
+        new CollectionInstrumentSelectionRule[] {
+          new CollectionInstrumentSelectionRule(100, "this is not SPEL", "dummyUrl")
+        });
+
+    when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(new Survey()));
+
+    ResponseStatusException thrown =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> underTest.createCollectionExercises(collectionExerciseDto, null));
+
+    assertThat(thrown.getReason()).isEqualTo("Invalid SPEL: this is not SPEL");
+  }
+
+  @Test
+  void createCollectionExercisesRejectsBlankInstrumentUrl() {
+    CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+    collectionExerciseDto.setSurveyId(UUID.randomUUID());
+    collectionExerciseDto.setCollectionInstrumentSelectionRules(
+        new CollectionInstrumentSelectionRule[] {
+          new CollectionInstrumentSelectionRule(100, "true == false", "")
+        });
+
+    when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(new Survey()));
+
+    ResponseStatusException thrown =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> underTest.createCollectionExercises(collectionExerciseDto, null));
+
+    assertThat(thrown.getReason()).isEqualTo("CI URL cannot be blank");
+  }
+
+  @Test
+  void createCollectionExercisesRejectsMissingDefault() {
+    CollectionExerciseDto collectionExerciseDto = new CollectionExerciseDto();
+    collectionExerciseDto.setSurveyId(UUID.randomUUID());
+    collectionExerciseDto.setCollectionInstrumentSelectionRules(
+        new CollectionInstrumentSelectionRule[] {
+          new CollectionInstrumentSelectionRule(100, "true == false", "dummyUrl")
+        });
+
+    when(surveyRepository.findById(any(UUID.class))).thenReturn(Optional.of(new Survey()));
+
+    ResponseStatusException thrown =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> underTest.createCollectionExercises(collectionExerciseDto, null));
+
+    assertThat(thrown.getReason())
+        .isEqualTo("Rules must include zero priority default with null expression");
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Case;
 import uk.gov.ons.ssdc.common.model.entity.CollectionExercise;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
 import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.ExportFileTemplate;
 import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
@@ -187,6 +188,10 @@ public class IntegrationTestHelper {
     collectionExercise.setStartDate(OffsetDateTime.now());
     collectionExercise.setEndDate(OffsetDateTime.now().plusDays(2));
     collectionExercise.setMetadata(TEST_COLLECTION_EXERCISE_UPDATE_METADATA);
+    collectionExercise.setCollectionInstrumentSelectionRules(
+        new CollectionInstrumentSelectionRule[] {
+          new CollectionInstrumentSelectionRule(0, null, "test instrument")
+        });
     collectionExercise = collectionExerciseRepository.saveAndFlush(collectionExercise);
 
     Case caze = new Case();
@@ -198,7 +203,9 @@ public class IntegrationTestHelper {
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid("TEST_QID_" + UUID.randomUUID());
     uacQidLink.setUac("TEST_UAC_" + UUID.randomUUID());
+    uacQidLink.setUacHash("test fake hash");
     uacQidLink.setCaze(caze);
+    uacQidLink.setCollectionInstrumentUrl("test instrument url");
     uacQidLink = uacQidLinkRepository.saveAndFlush(uacQidLink);
 
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -252,7 +252,7 @@ class SurveyDetails extends Component {
       newCollectionExerciseDateError: "",
       newCollectionExerciseCIRules: "",
       newCollectionExerciseCIRulesError: false,
-      });
+    });
   };
 
   closeCreateCollectionExerciseDialog = () => {
@@ -361,7 +361,7 @@ class SurveyDetails extends Component {
     } else {
       this.setState({ newCollectionExerciseCIRulesError: true });
       validationFailed = true;
-  }
+    }
 
     if (validationFailed) {
       this.createCollectionExerciseInProgress = false;

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -46,6 +46,8 @@ class SurveyDetails extends Component {
     newCollectionExerciseDateError: "",
     newCollectionExerciseMetadata: "",
     newCollectionExerciseMetadataError: false,
+    newCollectionExerciseCIRules: "",
+    newCollectionExerciseCIRulesError: false,
     allowActionRuleExportFileTemplateDialogDisplayed: false,
     allowActionRuleSmsTemplateDialogDisplayed: false,
     allowActionRuleEmailTemplateDialogDisplayed: false,
@@ -248,7 +250,9 @@ class SurveyDetails extends Component {
       createCollectionExerciseDialogDisplayed: true,
       newCollectionExerciseMetadataError: false,
       newCollectionExerciseDateError: "",
-    });
+      newCollectionExerciseCIRules: "",
+      newCollectionExerciseCIRulesError: false,
+      });
   };
 
   closeCreateCollectionExerciseDialog = () => {
@@ -289,6 +293,13 @@ class SurveyDetails extends Component {
     this.setState({
       newCollectionExerciseMetadata: event.target.value,
       newCollectionExerciseMetadataError: false,
+    });
+  };
+
+  onNewCollectionExerciseCIRulesChange = (event) => {
+    this.setState({
+      newCollectionExerciseCIRules: event.target.value,
+      newCollectionExerciseCIRulesError: false,
     });
   };
 
@@ -335,6 +346,23 @@ class SurveyDetails extends Component {
       }
     }
 
+    let ciRulesJson = null;
+    if (this.state.newCollectionExerciseCIRules.length > 0) {
+      try {
+        ciRulesJson = JSON.parse(this.state.newCollectionExerciseCIRules);
+        if (Object.keys(ciRulesJson).length === 0) {
+          this.setState({ newCollectionExerciseCIRulesError: true });
+          validationFailed = true;
+        }
+      } catch (err) {
+        this.setState({ newCollectionExerciseCIRulesError: true });
+        validationFailed = true;
+      }
+    } else {
+      this.setState({ newCollectionExerciseCIRulesError: true });
+      validationFailed = true;
+  }
+
     if (validationFailed) {
       this.createCollectionExerciseInProgress = false;
       return;
@@ -349,6 +377,7 @@ class SurveyDetails extends Component {
       ).toISOString(),
       endDate: new Date(this.state.newCollectionExerciseEndDate).toISOString(),
       metadata: metadataJson,
+      collectionInstrumentSelectionRules: ciRulesJson,
     };
 
     const response = await fetch("/api/collectionExercises", {
@@ -1055,7 +1084,6 @@ class SurveyDetails extends Component {
                   required
                   fullWidth={true}
                   error={this.state.newCollectionExerciseNameError}
-                  id="standard-required"
                   label="Collection exercise name"
                   onChange={this.onNewCollectionExerciseNameChange}
                   value={this.state.newCollectionExerciseName}
@@ -1064,7 +1092,6 @@ class SurveyDetails extends Component {
                   required
                   fullWidth={true}
                   error={this.state.newCollectionExerciseReferenceError}
-                  id="standard-required"
                   label="Reference"
                   onChange={this.onNewCollectionExerciseReferenceChange}
                   value={this.state.newCollectionExerciseReference}
@@ -1099,10 +1126,19 @@ class SurveyDetails extends Component {
                   multiline
                   fullWidth={true}
                   error={this.state.newCollectionExerciseMetadataError}
-                  id="standard-required"
                   label="Metadata"
                   onChange={this.onNewCollectionExerciseMetadataChange}
                   value={this.state.newCollectionExerciseMetadata}
+                />
+                <TextField
+                  style={{ marginTop: 10 }}
+                  multiline
+                  required
+                  fullWidth={true}
+                  error={this.state.newCollectionExerciseCIRulesError}
+                  label="CI Rules"
+                  onChange={this.onNewCollectionExerciseCIRulesChange}
+                  value={this.state.newCollectionExerciseCIRules}
                 />
               </div>
               <div style={{ marginTop: 10 }}>


### PR DESCRIPTION
# Motivation and Context
Choosing the correct collection instrument (CI) for a respondent needs to be rules-based, because there are myriad known and unknown requirements that the ONS has, regarding which questionnaire the organisation wants a respondent to fill in.

# What has changed
Allowed a block of rules for choosing a collection instrument to be stored against a collection exercise, and these rules are then used to choose the right CI at the moment when the action rule runs.

This has been performance tested with 10k cases, which took 3 minutes to produce the print file = 55/second... pretty slow. but this was on my local MacBook running with the Pub/Sub emulator, and in debug mode. It should scale horizontally, and besides, we need to know what the performance was before for a like-for-like comparison.

We could try choosing the CI when we load the sample, like RAS-RM does, but that just moves the problem around, and it's far less elegant because the CI is not then changing dynamically as the case moves between waves.

I think it's unavoidable that this is a CPU intensive operation, and we simply need to beef up the amount of CPU we give to the Case Processor to accommodate the demand, for massive surveys. At Census scale we would run 10 or more Case Processors.

# How to test?
Set up a survey, then when setting up a collection exercise use these collection instrument rules (or similar):
```json
[
  {
    "priority": 1000,
    "spelExpression": "caze.sample['POSTCODE'] == 'abc123' and uacMetadata != null and uacMetadata['wave'] == 1",
    "collectionInstrumentUrl": "http://quiteAspecific/survey"
  },
  {
    "priority": 500,
    "spelExpression": "caze.sample['POSTCODE'] == 'xyz999'",
    "collectionInstrumentUrl": "http://slightlyLessSpecific/survey"
  },
  {
    "priority": 0,
    "spelExpression": null,
    "collectionInstrumentUrl": "http://allPurpose/survey"
  }
]
```

Then, set up an action rule which includes a UAC (e.g. `["__uac__"]`).

When the action rule triggers, you should be able to see the CI in the emitted `uacUpdate` events, and in the database.

# Links
Trello: https://trello.com/c/SDRjFfs3

# Screenshots
<img width="661" alt="Screenshot 2021-11-16 at 17 55 52" src="https://user-images.githubusercontent.com/41681172/142039573-e4bc9f44-917a-4416-8800-e3c0400abd79.png">
