### PR TITLE
Migrate to shared events version 0.5.0 release

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/utility/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/utility/Constants.java
@@ -1,5 +1,5 @@
 package uk.gov.ons.ssdc.supporttool.utility;
 
 public class Constants {
-  public static final String EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final String EVENT_SCHEMA_VERSION = "0.5.0";
 }


### PR DESCRIPTION
# Motivation and Context
We have released `0.5.0` of the [shared events](https://github.com/ONSdigital/ssdc-shared-events) so it's time to bring our microservices in line with that spec.

# What has changed
Changed all the microservices to publish `0.5.0` as the event version in the headers, and do a few other tweaks to meet the specification.

Also, allow some more versions to be sent to us for present and future needs.

# How to test?
Zero regression - ATs should pass.

# Links
Trello: https://trello.com/c/9uTTLrLW