### PR TITLE
Bump common entities version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.7.0-SNAPSHOT</version>
+      <version>4.8.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>


### PR DESCRIPTION
# Motivation and Context
If two processes attempt to simultaneously update the data on an `@Entity` then the whole data row will be replaced by whatever is in memory, by default. By using the `@DynamicUpdate` Spring Data JPA annotation, we indicate to JPA, and in turn to Hibernate, that we want an update SQL statement to be created, which will _only update the values which have changed_ by using a 'proxy' object... whenever we call a setter on the proxy, JPA/Hibernate knows that we wish for that data item to be updated, but none of the other items.

By using `@DynamicUpdate` we suffer a minor performance penalty, because the SQL statement will be prepared _dynamically_ rather than pre-prepared and cached... but the benefit is clear in terms of not over-writing changes which happened simultanously.

# What has changed
Added `@DynamicUpdate` to all the JPA entities.

# How to test?
Should be zero noticeable change, but you _could_ try doing simultaneous refusal and invalid on cases, and check that those flags are not 'lost'... in Census we did see (in very rare circumstances) that we lost the flags because of this problem.

Pretty much just run the ATs.

# Links
Trello: https://trello.com/c/4TzJNke2