### PR TITLE
Upgrade to Java 17 and Spring Boot 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 jobs:
   include:
     - language: java
-      jdk: openjdk11
+      jdk: openjdk17
       name: Java Service Build
 
       before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:11-slim
-CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
+FROM openjdk:17-slim
+CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
 
 RUN groupadd --gid 999 supporttool && \
     useradd --create-home --system --uid 999 --gid supporttool supporttool

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.9.0-SNAPSHOT</version>
+      <version>4.10.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,11 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.3</version>
+    <version>2.6.0</version>
   </parent>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>
@@ -77,6 +77,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-stackdriver</artifactId>
+      <version>1.8.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
     </dependency>
@@ -102,8 +107,8 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-      <version>1.5.1</version>
+      <artifactId>micrometer-registry-stackdriver</artifactId>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -253,7 +258,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>
@@ -272,8 +277,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.11</source>
-          <target>1.11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,15 @@ management:
   health:
     pubsub:
       enabled: false
+  metrics:
+    tags:
+      application: Support Tool
+      pod: ${HOSTNAME}
+    export:
+      stackdriver:
+        project-id: dummy-project-id
+        enabled: false
+        step: PT1M
 
 notifyservice:
   connection:


### PR DESCRIPTION
# Motivation and Context
Java 11 is no longer the LTS (Long-Term Support) version. Java 17 is the LTS version, so we should use that.

Spring Boot 2.6.0 is the first version of Spring Boot to support Java 17, so we should use that too.

# What has changed
Upgraded to Java 17 and Spring Boot 2.6.0, plus upped any other versions required for everything to work.

Switched the Docker base image over to be JDK 17 too.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/kcJGECdH