### PR TITLE
Fix missing handler for allow SMS template on action rule

### DIFF
--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -503,6 +503,46 @@ class SurveyDetails extends Component {
     }
   };
 
+  onAllowActionRuleSmsTemplate = async () => {
+    if (this.allowActionRuleSmsTemplateInProgress) {
+      return;
+    }
+
+    this.allowActionRuleSmsTemplateInProgress = true;
+
+    if (!this.state.smsTemplateToAllow) {
+      this.setState({
+        smsTemplateValidationError: true,
+      });
+
+      this.allowActionRuleSmsTemplateInProgress = false;
+      return;
+    }
+
+    const newAllowSmsTemplate = {
+      surveyId: this.props.surveyId,
+      packCode: this.state.smsTemplateToAllow,
+    };
+
+    const response = await fetch("/api/actionRuleSurveySmsTemplates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newAllowSmsTemplate),
+    });
+
+    if (response.ok) {
+      this.setState({
+        allowActionRuleSmsTemplateDialogDisplayed: false,
+      });
+    } else {
+      const errorMessage = await response.text();
+      this.setState({
+        allowSmsTemplateError: errorMessage,
+      });
+      this.allowActionRuleSmsTemplateInProgress = false;
+    }
+  };
+
   onAllowActionRuleEmailTemplate = async () => {
     if (this.allowActionRuleEmailTemplateInProgress) {
       return;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The handler function was missing, meaning the "Allow SMS Template On Action Rule" submit button simply didn't work.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add missing handler to UI

# How to test?
Try allowing an SMS template for action rules on a survey

# Links
https://trello.com/c/JIjNalrX/3139-defect-allow-sms-template-on-action-rules-has-no-submit-button-handler
