### PR TITLE
Global Permissions Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.10.0-SNAPSHOT</version>
+      <version>4.12.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
@@ -4,10 +4,12 @@ import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityTyp
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -69,8 +71,16 @@ public class AuthorisationEndpoint {
             && (permission.getSurvey() == null
                 || (surveyId.isPresent()
                     && permission.getSurvey().getId().equals(surveyId.get())))) {
-          // User is a global super user or super user on the specified survey: give all permissions
-          return Set.of(UserGroupAuthorisedActivityType.values());
+          if (permission.getSurvey() == null) {
+            // User is a global super user so give ALL permissions
+            return Set.of(UserGroupAuthorisedActivityType.values());
+          } else {
+            // User is a super user ONLY ON ONE SPECIFIC SURVEY so just give non-global permissions
+            result.addAll(
+                Arrays.stream(UserGroupAuthorisedActivityType.values())
+                    .filter(activityType -> !activityType.isGlobal())
+                    .collect(Collectors.toSet()));
+          }
         } else if (permission.getSurvey() != null
             && surveyId.isPresent()
             && permission.getSurvey().getId().equals(surveyId.get())) {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisedActivityTypesEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisedActivityTypesEndpoint.java
@@ -1,19 +1,33 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 
 @RestController
 @RequestMapping(value = "/api/authorisedActivityTypes")
 public class AuthorisedActivityTypesEndpoint {
-  private static final Set<UserGroupAuthorisedActivityType> AUTHORISED_ACTIVITY_TYPES =
+  private static final Set<UserGroupAuthorisedActivityType> ALL_AUTHORISED_ACTIVITY_TYPES =
       Set.of(UserGroupAuthorisedActivityType.values());
 
+  private static final Set<UserGroupAuthorisedActivityType> GLOBAL_AUTHORISED_ACTIVITY_TYPES =
+      Arrays.stream(UserGroupAuthorisedActivityType.values())
+          .filter(UserGroupAuthorisedActivityType::isGlobal)
+          .collect(Collectors.toSet());
+
   @GetMapping
-  Set<UserGroupAuthorisedActivityType> getAllAuthorisedActivities() {
-    return AUTHORISED_ACTIVITY_TYPES;
+  Set<UserGroupAuthorisedActivityType> getAuthorisedActivities(
+      @RequestParam(value = "globalOnly", required = false, defaultValue = "false")
+          boolean globalOnly) {
+    if (globalOnly) {
+      return GLOBAL_AUTHORISED_ACTIVITY_TYPES;
+    } else {
+      return ALL_AUTHORISED_ACTIVITY_TYPES;
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupPermissionEndpoint.java
@@ -88,6 +88,12 @@ public class UserGroupPermissionEndpoint {
 
     Survey survey = null;
     if (userGroupPermissionDto.getSurveyId() != null) {
+      if (userGroupPermissionDto.getAuthorisedActivity().isGlobal()) {
+        // Not allowed to use a global permission on a specific survey... doesn't work; nonsensical!
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Global permissions must be global");
+      }
+
       survey =
           surveyRepository
               .findById(userGroupPermissionDto.getSurveyId())

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -72,9 +72,11 @@ public class UserIdentity {
             || (permission.getAuthorisedActivity() == UserGroupAuthorisedActivityType.SUPER_USER
                     && permission.getSurvey() != null
                     && permission.getSurvey().getId().equals(survey.getId())
-                // Otherwise, user must have specific activity/survey combo to be authorised
+                // Otherwise, user must have GLOBAL permission for specific activity
+                // OR the specific activity/survey combo has to be authorised EXACTLY
                 || (permission.getAuthorisedActivity() == activity
                     && (permission.getSurvey() == null
+                        || permission.getAuthorisedActivity().isGlobal()
                         || (permission.getSurvey() != null
                             && permission.getSurvey().getId().equals(survey.getId())))))) {
           return; // User is authorised

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -72,11 +72,9 @@ public class UserIdentity {
             || (permission.getAuthorisedActivity() == UserGroupAuthorisedActivityType.SUPER_USER
                     && permission.getSurvey() != null
                     && permission.getSurvey().getId().equals(survey.getId())
-                // Otherwise, user must have GLOBAL permission for specific activity
-                // OR the specific activity/survey combo has to be authorised EXACTLY
+                // Otherwise, user must have specific activity/survey combo to be authorised
                 || (permission.getAuthorisedActivity() == activity
                     && (permission.getSurvey() == null
-                        || permission.getAuthorisedActivity().isGlobal()
                         || (permission.getSurvey() != null
                             && permission.getSurvey().getId().equals(survey.getId())))))) {
           return; // User is authorised


### PR DESCRIPTION
# Motivation and Context
Global permissions need to be handled differently from survey-specific permissions. For example, being able to see the list of SMS templates is not something survey specific. As such, it's hard for our UI to know what APIs are allowed to be called.

To solve this problem, by marking global permissions as global, we can filter those permissions out when the user is a super user on a specific survey, so it doesn't confuse the UI.

# What has changed
Added `global` flag to permissions. Filtered out the global permissions for survey specific super users. Denied any requests to use global permissions on specific surveys, because that's nonsense.

There's still some UI work to do to prevent people from attempting to put global permissions on surveys, but the backend will prevent it.

# How to test?
Try it out.

# Links
Trello: https://trello.com/c/DrxN8MHD