### PR TITLE
When incorrect CI rules are corrected error is reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ values ('c469377e-680e-4cb1-92a0-5217be2b3a52', -- permission ID
         '8269d75c-bfa1-4930-aca2-10dd9c6a2b42', -- group ID
         null);
 ```
+

--- a/ui/src/SurveyDetails.js
+++ b/ui/src/SurveyDetails.js
@@ -388,6 +388,8 @@ class SurveyDetails extends Component {
 
     if (response.ok) {
       this.setState({ createCollectionExerciseDialogDisplayed: false });
+    } else {
+      this.createCollectionExerciseInProgress = false;
     }
   };
 


### PR DESCRIPTION
# Motivation and Context
When a user fixes bad CI rules, the new collex dialog doesn't reset the error, so the collex can't be created until the dialog is closed and reopened.

# What has changed
Reset the error flag when there's a backend error.

# How to test?
Enter bad CI rules and click to submit the new collection exercise, then fix the CI rules and click the button to submit the collex a second time... it should then work.

# Links
Trello: https://trello.com/c/OiC1uWuo