### PR TITLE
Use CSVParserBuilder and CSVReaderBuilder instead of deprecated constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ values ('c469377e-680e-4cb1-92a0-5217be2b3a52', -- permission ID
         '8269d75c-bfa1-4930-aca2-10dd9c6a2b42', -- group ID
         null);
 ```
+
+

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
@@ -2,7 +2,10 @@ package uk.gov.ons.ssdc.supporttool.schedule;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import com.opencsv.CSVParser;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -64,9 +67,12 @@ public class FileStager {
   }
 
   private JobStatus checkHeaderRow(Job job) {
+    CSVParser parser =
+        new CSVParserBuilder()
+            .withSeparator(job.getCollectionExercise().getSurvey().getSampleSeparator())
+            .build();
     try (Reader reader = Files.newBufferedReader(Path.of(fileUploadStoragePath + job.getFileId()));
-        CSVReader csvReader =
-            new CSVReader(reader, job.getCollectionExercise().getSurvey().getSampleSeparator())) {
+        CSVReader csvReader = new CSVReaderBuilder(reader).withCSVParser(parser).build()) {
       JobStatus jobStatus = JobStatus.STAGING_IN_PROGRESS;
 
       // Validate the header row has the right number of columns

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -2,7 +2,10 @@ package uk.gov.ons.ssdc.supporttool.schedule;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import com.opencsv.CSVParser;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -68,9 +71,12 @@ public class RowStager {
   }
 
   private void processJob(Job job) {
+    CSVParser parser =
+        new CSVParserBuilder()
+            .withSeparator(job.getCollectionExercise().getSurvey().getSampleSeparator())
+            .build();
     try (Reader reader = Files.newBufferedReader(Path.of(fileUploadStoragePath + job.getFileId()));
-        CSVReader csvReader =
-            new CSVReader(reader, job.getCollectionExercise().getSurvey().getSampleSeparator())) {
+        CSVReader csvReader = new CSVReaderBuilder(reader).withCSVParser(parser).build()) {
 
       String[] headerRow;
       int headerRowCorrection = 1;


### PR DESCRIPTION
# Motivation and Context
OpenCSV used to have a very good, useful, excellent and generally awesome API. Now it does not.

# What has changed
Changed to use the very bad API.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/tSfAbCHV