### PR TITLE
Hide process button if all rows fail validation

### DIFF
--- a/ui/src/JobDetails.js
+++ b/ui/src/JobDetails.js
@@ -260,23 +260,31 @@ class JobDetails extends Component {
               ) &&
               ["VALIDATED_OK", "VALIDATED_WITH_ERRORS"].includes(
                 this.props.job.jobStatus
+              ) &&
+              this.props.job.rowErrorCount <
+                this.props.job.fileRowCount - headerRowCorrection && (
+                <Button
+                  onClick={this.props.onProcessJob}
+                  variant="contained"
+                  style={{ margin: 10 }}
+                >
+                  Process
+                </Button>
+              )}
+            {this.props.job &&
+              this.props.authorisedActivities.includes(
+                this.props.loadPermission
+              ) &&
+              ["VALIDATED_OK", "VALIDATED_WITH_ERRORS"].includes(
+                this.props.job.jobStatus
               ) && (
-                <>
-                  <Button
-                    onClick={this.props.onProcessJob}
-                    variant="contained"
-                    style={{ margin: 10 }}
-                  >
-                    Process
-                  </Button>
-                  <Button
-                    onClick={this.props.onCancelJob}
-                    variant="contained"
-                    style={{ margin: 10 }}
-                  >
-                    Cancel
-                  </Button>
-                </>
+                <Button
+                  onClick={this.props.onCancelJob}
+                  variant="contained"
+                  style={{ margin: 10 }}
+                >
+                  Cancel
+                </Button>
               )}
             <Button
               onClick={this.props.handleClosedDetails}


### PR DESCRIPTION
# Motivation and Context
Allowing users to 'process' a file which every single row failed validation of, might be confusing/misleading... although it's in the support tool, so users should be "power" users who know what they're doing... but anyway it's useful to think about these things and show how they "should" be done, maybe, without any formal user research.

# What has changed
Hid the "process" button if all the rows failed validation.

# How to test?
Upload a sample file (or indeed any kind of CSV file) that has problems on EVERY SINGLE row, causing it to totally fail validation on all rows. Then, check that the "process" button is not available.

# Links
Trello: https://trello.com/c/J6MaW5N3

# Screenshots (if appropriate):
<img width="682" alt="Screenshot 2021-12-14 at 17 40 05" src="https://user-images.githubusercontent.com/41681172/146051052-8c0800e5-ca30-4e19-a991-5907b45da39f.png">
