### PR TITLE
3209 Print fulfilment request personalisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.13.0-SNAPSHOT</version>
+      <version>4.14.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-stackdriver</artifactId>
-      <version>1.8.0</version>
+      <version>1.8.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-55</artifactId>
-      <version>2.12.1</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>4.1</version>
+      <version>4.6</version>
     </dependency>
 
     <!--    Test Dependencies below this point -->
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
-      <version>2.27.0</version>
+      <version>2.32.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/utility/AllowTemplateOnSurveyValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/utility/AllowTemplateOnSurveyValidator.java
@@ -24,9 +24,13 @@ public class AllowTemplateOnSurveyValidator {
     surveyColumnsPlusOtherAllowableColumns.addAll(sensitiveSurveyColumns);
     surveyColumnsPlusOtherAllowableColumns.addAll(OTHER_ALLOWABLE_COLUMNS);
 
-    if (!surveyColumnsPlusOtherAllowableColumns.containsAll(templateColumns)) {
-      Set<String> printTemplateColumnsNotAllowed = new HashSet<>();
-      printTemplateColumnsNotAllowed.addAll(templateColumns);
+    // We can't validate the __request__ columns as the caller supplies them not the sample
+    Set<String> templateNonRequestColumns = new HashSet<>(templateColumns);
+    templateNonRequestColumns.removeIf(column -> column.startsWith("__request__."));
+
+    if (!surveyColumnsPlusOtherAllowableColumns.containsAll(templateNonRequestColumns)) {
+      Set<String> printTemplateColumnsNotAllowed = new HashSet<>(templateNonRequestColumns);
+      //      printTemplateColumnsNotAllowed.addAll(templateColumns);
       printTemplateColumnsNotAllowed.removeAll(surveyColumnsPlusOtherAllowableColumns);
       String errorMessage =
           "Survey is missing columns: " + String.join(", ", printTemplateColumnsNotAllowed);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/utility/AllowTemplateOnSurveyValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/utility/AllowTemplateOnSurveyValidator.java
@@ -30,7 +30,6 @@ public class AllowTemplateOnSurveyValidator {
 
     if (!surveyColumnsPlusOtherAllowableColumns.containsAll(templateNonRequestColumns)) {
       Set<String> printTemplateColumnsNotAllowed = new HashSet<>(templateNonRequestColumns);
-      //      printTemplateColumnsNotAllowed.addAll(templateColumns);
       printTemplateColumnsNotAllowed.removeAll(surveyColumnsPlusOtherAllowableColumns);
       String errorMessage =
           "Survey is missing columns: " + String.join(", ", printTemplateColumnsNotAllowed);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to enable print fulfilment requests to supply extra personalisation values beyond what is stored on the case. The support tool template validation needs updating to allow these fields in the template when linking to a survey.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Allow `__request__.` fields in template when linking to survey 
- Bump some minor dependency versions 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build service branches, run the AT branch.

# Links
https://trello.com/c/fwLbkDJy/3209-ability-to-include-a-name-on-a-fulfilment-by-post-8