### PR TITLE
3245 Add request personalisation to print fulfilment request

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
@@ -53,7 +53,6 @@ public class FulfilmentSurveyExportFileTemplateEndpoint {
   }
 
   @GetMapping
-  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
   public List<ExportFileTemplateDto> getAllowedPackCodesBySurvey(
       @RequestParam(value = "surveyId") UUID surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +21,7 @@ import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyExportFileTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.ExportFileTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.repository.ExportFileTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveyExportFileTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
@@ -54,7 +54,7 @@ public class FulfilmentSurveyExportFileTemplateEndpoint {
 
   @GetMapping
   // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
-  public List<String> getAllowedPackCodesBySurvey(
+  public List<ExportFileTemplateDto> getAllowedPackCodesBySurvey(
       @RequestParam(value = "surveyId") UUID surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
@@ -69,8 +69,8 @@ public class FulfilmentSurveyExportFileTemplateEndpoint {
         UserGroupAuthorisedActivityType.LIST_ALLOWED_EXPORT_FILE_TEMPLATES_ON_FULFILMENTS);
 
     return fulfilmentSurveyExportFileTemplateRepository.findBySurvey(survey).stream()
-        .map(fspt -> fspt.getExportFileTemplate().getPackCode())
-        .collect(Collectors.toList());
+        .map(fspt -> new ExportFileTemplateDto(fspt.getExportFileTemplate()))
+        .toList();
   }
 
   @PostMapping

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/PrintFulfilmentDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/PrintFulfilmentDTO.java
@@ -8,4 +8,5 @@ public class PrintFulfilmentDTO {
   private UUID caseId;
   private String packCode;
   private Object uacMetadata;
+  private Object personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ExportFileTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ExportFileTemplateDto.java
@@ -1,12 +1,23 @@
 package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ssdc.common.model.entity.ExportFileTemplate;
 
 @Data
+@NoArgsConstructor
 public class ExportFileTemplateDto {
   private String packCode;
   private String[] template;
   private String exportFileDestination;
   private String description;
   private Object metadata;
+
+  public ExportFileTemplateDto(ExportFileTemplate exportFileTemplate) {
+    packCode = exportFileTemplate.getPackCode();
+    template = exportFileTemplate.getTemplate();
+    exportFileDestination = exportFileTemplate.getExportFileDestination();
+    description = exportFileTemplate.getDescription();
+    metadata = exportFileTemplate.getMetadata();
+  }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/PrintFulfilment.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/PrintFulfilment.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class PrintFulfilment {
   private String packCode;
   private Object uacMetadata;
+  private Object personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/service/CaseService.java
@@ -133,6 +133,7 @@ public class CaseService {
     printFulfilmentDTO.setCaseId(caze.getId());
     printFulfilmentDTO.setPackCode(printFulfilment.getPackCode());
     printFulfilmentDTO.setUacMetadata(printFulfilment.getUacMetadata());
+    printFulfilmentDTO.setPersonalisation(printFulfilment.getPersonalisation());
 
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setPrintFulfilment(printFulfilmentDTO);

--- a/ui/src/AllowedExportFileTemplatesOnFulfilmentsList.js
+++ b/ui/src/AllowedExportFileTemplatesOnFulfilmentsList.js
@@ -26,8 +26,8 @@ import {
 class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
   state = {
     authorisedActivities: [],
-    fulfilmentExportFileTemplates: [],
-    allowableFulfilmentExportFileTemplates: [],
+    fulfilmentExportFilePackCodes: [],
+    allowableFulfilmentExportFilePackCodes: [],
     allowFulfilmentExportFileTemplateDialogDisplayed: false,
     exportFileTemplateToAllow: "",
     exportFileTemplateValidationError: false,
@@ -55,7 +55,7 @@ class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allExportFileFulfilmentTemplates = await getAllExportFileTemplates(
+    const allExportFileFulfilmentPackCodes = await getAllExportFileTemplates(
       authorisedActivities
     );
 
@@ -64,19 +64,21 @@ class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
         authorisedActivities,
         this.props.surveyId
       );
+    const fulfilmentExportFilePackCodes = fulfilmentExportFileTemplates.map(
+      (template) => template.packCode
+    );
+    let allowableFulfilmentExportFilePackCodes = [];
 
-    let allowableFulfilmentExportFileTemplates = [];
-
-    allExportFileFulfilmentTemplates.forEach((packCode) => {
-      if (!fulfilmentExportFileTemplates.includes(packCode)) {
-        allowableFulfilmentExportFileTemplates.push(packCode);
+    allExportFileFulfilmentPackCodes.forEach((packCode) => {
+      if (!fulfilmentExportFilePackCodes.includes(packCode)) {
+        allowableFulfilmentExportFilePackCodes.push(packCode);
       }
     });
 
     this.setState({
-      fulfilmentExportFileTemplates: fulfilmentExportFileTemplates,
-      allowableFulfilmentExportFileTemplates:
-        allowableFulfilmentExportFileTemplates,
+      fulfilmentExportFilePackCodes: fulfilmentExportFilePackCodes,
+      allowableFulfilmentExportFilePackCodes:
+        allowableFulfilmentExportFilePackCodes,
     });
   };
 
@@ -141,14 +143,14 @@ class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
 
   render() {
     const fulfilmentExportFileTemplateMenuItems =
-      this.state.allowableFulfilmentExportFileTemplates.map((packCode) => (
+      this.state.allowableFulfilmentExportFilePackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>
       ));
 
     const fulfilmentExportFileTemplateTableRows =
-      this.state.fulfilmentExportFileTemplates.map((exportFileTemplate) => (
+      this.state.fulfilmentExportFilePackCodes.map((exportFileTemplate) => (
         <TableRow key={exportFileTemplate}>
           <TableCell component="th" scope="row">
             {exportFileTemplate}

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -61,6 +61,7 @@ class PrintFulfilment extends Component {
       selectedTemplate: null,
       personalisationFormItems: "",
       packCodeValidationError: false,
+      printUacQidMetadataValidationError: false,
       showDialog: false,
       newPrintUacQidMetadata: "",
       personalisationValues: null,
@@ -167,7 +168,6 @@ class PrintFulfilment extends Component {
                 id={"personalisationKey-" + personalisationKey}
                 name={personalisationKey}
                 onChange={this.onPersonalisationValueChange}
-                value={this.state.personalisationValues?.personalisationKey}
               />
             </FormControl>
           )

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -240,7 +240,7 @@ class PrintFulfilment extends Component {
                   value={this.state.newPrintUacQidMetadata}
                 />
               </FormControl>
-              {!(this.state.selectedTemplate === null) &&
+              {this.state.selectedTemplate !== null &&
                 this.state.personalisationFormItems !== "" && (
                   <fieldset>
                     <label>Request Personalisation</label>

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -14,12 +14,14 @@ import { getFulfilmentExportFileTemplates } from "./Utils";
 
 class PrintFulfilment extends Component {
   state = {
-    packCode: "",
+    selectedTemplate: null,
     allowableFulfilmentExportFileTemplates: [],
-    packCodeValidationError: false,
+    templateValidationError: false,
     printUacQidMetadataValidationError: false,
     showDialog: false,
     newPrintUacQidMetadata: "",
+    personalisationFormItems: "",
+    personalisationValues: null,
   };
 
   componentDidMount() {
@@ -56,15 +58,18 @@ class PrintFulfilment extends Component {
 
   closeDialog = () => {
     this.setState({
-      packCode: "",
+      selectedTemplate: null,
+      personalisationFormItems: "",
       packCodeValidationError: false,
       showDialog: false,
       newPrintUacQidMetadata: "",
+      personalisationValues: null,
     });
   };
 
   onPrintTemplateChange = (event) => {
-    this.setState({ packCode: event.target.value });
+    this.setState({ selectedTemplate: event.target.value });
+    this.updatePersonalisationFormItems(event.target.value);
   };
 
   onNewActionRulePrintUacQidMetadataChange = (event) => {
@@ -72,6 +77,12 @@ class PrintFulfilment extends Component {
       newPrintUacQidMetadata: event.target.value,
       printUacQidMetadataValidationError: false,
     });
+  };
+
+  getTemplateRequestPersonalisationKeys = (templateKeys) => {
+    return templateKeys
+      .filter((templateKey) => templateKey.startsWith("__request__."))
+      .map((templateKey) => templateKey.replace("__request__.", ""));
   };
 
   onCreate = async () => {
@@ -83,9 +94,9 @@ class PrintFulfilment extends Component {
 
     let validationFailed = false;
 
-    if (!this.state.packCode) {
+    if (!this.state.selectedTemplate) {
       this.setState({
-        packCodeValidationError: true,
+        templateValidationError: true,
       });
 
       validationFailed = true;
@@ -112,8 +123,9 @@ class PrintFulfilment extends Component {
     }
 
     const printFulfilment = {
-      packCode: this.state.packCode,
+      packCode: this.state.selectedTemplate.packCode,
       uacMetadata: uacMetadataJson,
+      personalisation: this.state.personalisationValues,
     };
 
     const response = await fetch(
@@ -127,6 +139,39 @@ class PrintFulfilment extends Component {
 
     if (response.ok) {
       this.closeDialog();
+    }
+  };
+
+  onPersonalisationValueChange = (event) => {
+    let personalisationValuesToUpdate = this.state.personalisationValues
+      ? this.state.personalisationValues
+      : {};
+    personalisationValuesToUpdate[event.target.id] = event.target.value;
+    this.setState({ personalisationValues: personalisationValuesToUpdate });
+  };
+
+  updatePersonalisationFormItems = (selectedTemplate) => {
+    const requestTemplateKeys = this.getTemplateRequestPersonalisationKeys(
+      selectedTemplate.template
+    );
+
+    if (requestTemplateKeys.length === 0) {
+      this.setState({ personalisationFormItems: "" });
+    } else {
+      this.setState({
+        personalisationFormItems: requestTemplateKeys.map(
+          (personalisationKey) => (
+            <FormControl fullWidth={true} key={personalisationKey}>
+              <TextField
+                label={personalisationKey}
+                id={personalisationKey}
+                onChange={this.onPersonalisationValueChange}
+                value={this.state.personalisationValues?.personalisationKey}
+              />
+            </FormControl>
+          )
+        ),
+      });
     }
   };
 
@@ -151,11 +196,16 @@ class PrintFulfilment extends Component {
 
   render() {
     const fulfilmentPrintTemplateMenuItems =
-      this.state.allowableFulfilmentExportFileTemplates.map((packCode) => (
-        <MenuItem key={packCode} value={packCode}>
-          {packCode}
-        </MenuItem>
-      ));
+      this.state.allowableFulfilmentExportFileTemplates.map(
+        (selectedTemplate) => (
+          <MenuItem key={selectedTemplate.packCode} value={selectedTemplate}>
+            {selectedTemplate.packCode}
+          </MenuItem>
+        )
+      );
+
+    let fulfilmentPersonalisationFormItems =
+      this.state.personalisationFormItems;
 
     return (
       <div>
@@ -173,15 +223,15 @@ class PrintFulfilment extends Component {
                 <InputLabel>Export File Template</InputLabel>
                 <Select
                   onChange={this.onPrintTemplateChange}
-                  value={this.state.packCode}
-                  error={this.state.packCodeValidationError}
+                  value={this.state.selectedTemplate}
+                  error={this.state.templateValidationError}
                 >
                   {fulfilmentPrintTemplateMenuItems}
                 </Select>
               </FormControl>
               <FormControl fullWidth={true}>
                 <TextField
-                  style={{ minWidth: 200 }}
+                  style={{ minWidth: 200, marginBottom: 20 }}
                   error={this.state.printUacQidMetadataValidationError}
                   label="UAC QID Metadata"
                   id="standard-required"
@@ -189,6 +239,13 @@ class PrintFulfilment extends Component {
                   value={this.state.newPrintUacQidMetadata}
                 />
               </FormControl>
+              {!(this.state.selectedTemplate === null) &&
+                this.state.personalisationFormItems !== "" && (
+                  <fieldset>
+                    <label>Request Personalisation</label>
+                    {fulfilmentPersonalisationFormItems}
+                  </fieldset>
+                )}
             </div>
             <div style={{ marginTop: 10 }}>
               <Button

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -243,7 +243,7 @@ class PrintFulfilment extends Component {
               {this.state.selectedTemplate !== null &&
                 this.state.personalisationFormItems !== "" && (
                   <fieldset>
-                    <label>Request Personalisation</label>
+                    <label>Optional Request Personalisation</label>
                     {fulfilmentPersonalisationFormItems}
                   </fieldset>
                 )}

--- a/ui/src/PrintFulfilment.js
+++ b/ui/src/PrintFulfilment.js
@@ -146,7 +146,7 @@ class PrintFulfilment extends Component {
     let personalisationValuesToUpdate = this.state.personalisationValues
       ? this.state.personalisationValues
       : {};
-    personalisationValuesToUpdate[event.target.id] = event.target.value;
+    personalisationValuesToUpdate[event.target.name] = event.target.value;
     this.setState({ personalisationValues: personalisationValuesToUpdate });
   };
 
@@ -164,7 +164,8 @@ class PrintFulfilment extends Component {
             <FormControl fullWidth={true} key={personalisationKey}>
               <TextField
                 label={personalisationKey}
-                id={personalisationKey}
+                id={"personalisationKey-" + personalisationKey}
+                name={personalisationKey}
                 onChange={this.onPersonalisationValueChange}
                 value={this.state.personalisationValues?.personalisationKey}
               />

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -49,9 +49,8 @@ export const getFulfilmentExportFileTemplates = async (
   const response = await fetch(
     `/api/fulfilmentSurveyExportFileTemplates/?surveyId=${surveyId}`
   );
-  const exportFileTemplatesJson = await response.json();
-
-  return exportFileTemplatesJson;
+  const fulfilmentExportFileTemplates = await response.json();
+  return fulfilmentExportFileTemplates;
 };
 
 export const getSmsFulfilmentTemplates = async (


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Print fulfilments can now include extra personalisation values from the caller, where they are specified on the template. This PR adds form fields for these fields when they are found on the templates, so they can be sent from our UI.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Update the export template API to return the full template object
- In the UI, when an export file template is selected for print fulfilment, check if it includes any request fields and add a form field set including inputs for each of these request values
- Update print fulfilment backend endpoint to pass through personalisation values

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
1. Checkout this branch, run `make build`
1. Spin up our local stack with docker dev
1. Set up a case for a survey and allow an export file template on said survey which includes at least one `__request__.` prefixed field in the template 
1. Navigate to the case details page and request paper fulfilment
1. When you select the export template the request personalisation fields should pop up 
1. Try various combinations of supplying these values or not, the request should still work even if none are supplied, and should pass through any values you do set.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dCFLqaY4/3245-support-tool-personalisation-on-print-fulfilment-requests-8
