### PR TITLE
3288 - Prevent duplicate print template items in UI & backend

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ExportFileTemplateEndpoint.java
@@ -87,8 +87,8 @@ public class ExportFileTemplateEndpoint {
   }
 
   private void checkDuplicateTemplateItems(ExportFileTemplateDto exportFileTemplateDto) {
-    Set<String> exportFileTemplateDtoItemsSet = new HashSet<>(
-        Arrays.asList(exportFileTemplateDto.getTemplate()));
+    Set<String> exportFileTemplateDtoItemsSet =
+        new HashSet<>(Arrays.asList(exportFileTemplateDto.getTemplate()));
 
     if (exportFileTemplateDtoItemsSet.size() != exportFileTemplateDto.getTemplate().length) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -178,10 +178,10 @@ class ExportFileTemplateList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        const hasDuplicateTemplateItems = new Set(parsedJson).size !== parsedJson.length
+        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length
         if (!Array.isArray(parsedJson) ||
             parsedJson.length === 0 ||
-            hasDuplicateTemplateItems) {
+            hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -178,7 +178,9 @@ class ExportFileTemplateList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        if (!Array.isArray(parsedJson) || parsedJson.length === 0) {
+        if (!Array.isArray(parsedJson) ||
+            parsedJson.length === 0 ||
+            new Set(parsedJson).size !== parsedJson.length) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -33,6 +33,7 @@ class ExportFileTemplateList extends Component {
     template: "",
     descriptionValidationError: false,
     packCodeValidationError: false,
+    templateValidationErrorMessage: "",
     templateValidationError: false,
     newTemplateMetadataValidationError: false,
   };
@@ -100,6 +101,7 @@ class ExportFileTemplateList extends Component {
       exportFileDestinationValidationError: false,
       descriptionValidationError: false,
       packCodeValidationError: false,
+      templateValidationErrorMessage: "",
       templateValidationError: false,
       newTemplateMetadataValidationError: false,
       createExportFileTemplatePackCodeError: "",
@@ -142,11 +144,6 @@ class ExportFileTemplateList extends Component {
       failedValidation = true;
     }
 
-    if (!this.state.exportFileDestination.trim()) {
-      this.setState({ exportFileDestinationValidationError: true });
-      failedValidation = true;
-    }
-
     if (!this.state.description.trim()) {
       this.setState({ descriptionValidationError: true });
       failedValidation = true;
@@ -177,17 +174,22 @@ class ExportFileTemplateList extends Component {
       failedValidation = true;
     } else {
       try {
-        const parsedJson = JSON.parse(this.state.template);
-        const hasDuplicateTemplateColumns =
-          new Set(parsedJson).size !== parsedJson.length;
-        if (
-          !Array.isArray(parsedJson) ||
-          parsedJson.length === 0 ||
-          hasDuplicateTemplateColumns
-        ) {
+         const parsedJson = JSON.parse(this.state.template);
+        if (!Array.isArray(parsedJson) || parsedJson.length === 0) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }
+
+        const hasDuplicateTemplateColumns =
+            new Set(parsedJson).size !== parsedJson.length;
+        if (hasDuplicateTemplateColumns) {
+          this.setState({
+            templateValidationError: true,
+            templateValidationErrorMessage: "Template cannot have duplicate columns"
+          });
+          failedValidation = true;
+        }
+
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
@@ -262,6 +264,7 @@ class ExportFileTemplateList extends Component {
     this.setState({
       template: event.target.value,
       templateValidationError: resetValidation,
+      templateValidationErrorMessage: ""
     });
   };
 
@@ -386,7 +389,7 @@ class ExportFileTemplateList extends Component {
                   label="Template"
                   onChange={this.onTemplateChange}
                   value={this.state.template}
-                  helperText={this.state.notifyTemplateIdErrorMessage}
+                  helperText={this.state.templateValidationErrorMessage}
                 />
                 <TextField
                   fullWidth={true}

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -174,22 +174,22 @@ class ExportFileTemplateList extends Component {
       failedValidation = true;
     } else {
       try {
-         const parsedJson = JSON.parse(this.state.template);
+        const parsedJson = JSON.parse(this.state.template);
         if (!Array.isArray(parsedJson) || parsedJson.length === 0) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }
 
         const hasDuplicateTemplateColumns =
-            new Set(parsedJson).size !== parsedJson.length;
+          new Set(parsedJson).size !== parsedJson.length;
         if (hasDuplicateTemplateColumns) {
           this.setState({
             templateValidationError: true,
-            templateValidationErrorMessage: "Template cannot have duplicate columns"
+            templateValidationErrorMessage:
+              "Template cannot have duplicate columns",
           });
           failedValidation = true;
         }
-
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
@@ -264,7 +264,7 @@ class ExportFileTemplateList extends Component {
     this.setState({
       template: event.target.value,
       templateValidationError: resetValidation,
-      templateValidationErrorMessage: ""
+      templateValidationErrorMessage: "",
     });
   };
 

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -178,10 +178,13 @@ class ExportFileTemplateList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length
-        if (!Array.isArray(parsedJson) ||
-            parsedJson.length === 0 ||
-            hasDuplicateTemplateColumns) {
+        const hasDuplicateTemplateColumns =
+          new Set(parsedJson).size !== parsedJson.length;
+        if (
+          !Array.isArray(parsedJson) ||
+          parsedJson.length === 0 ||
+          hasDuplicateTemplateColumns
+        ) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -178,9 +178,10 @@ class ExportFileTemplateList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
+        const hasDuplicateTemplateItems = new Set(parsedJson).size !== parsedJson.length
         if (!Array.isArray(parsedJson) ||
             parsedJson.length === 0 ||
-            new Set(parsedJson).size !== parsedJson.length) {
+            hasDuplicateTemplateItems) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
         }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to prevent users from being able to generate a print template that contains duplicate columns

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated front and back end with validation for duplicates 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Should all still work as expected

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/K5hPmnRb/3288-print-fulfilment-template-gives-internal-server-error-when-trying-to-add-a-template-with-duplicate-attributes-to-a-survey-5

# Screenshots
<img width="950" alt="Screenshot 2022-03-02 at 08 46 03" src="https://user-images.githubusercontent.com/23473592/156326880-1b3a186b-2a36-4f2f-b27e-a470555aa18f.png">

