### PR TITLE
3246 Personalisation on SMS and email fulfilments

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CaseEndpoint.java
@@ -282,6 +282,7 @@ public class CaseEndpoint {
     smsFulfilment.setPackCode(smsFulfilmentAction.getPackCode());
     smsFulfilment.setPhoneNumber(smsFulfilmentAction.getPhoneNumber());
     smsFulfilment.setUacMetadata(smsFulfilmentAction.getUacMetadata());
+    smsFulfilment.setPersonalisation(smsFulfilmentAction.getPersonalisation());
 
     smsFulfilmentRequest.setHeader(header);
     payload.setSmsFulfilment(smsFulfilment);
@@ -321,6 +322,7 @@ public class CaseEndpoint {
     emailFulfilment.setPackCode(emailFulfilmentAction.getPackCode());
     emailFulfilment.setEmail(emailFulfilmentAction.getEmail());
     emailFulfilment.setUacMetadata(emailFulfilmentAction.getUacMetadata());
+    emailFulfilment.setPersonalisation(emailFulfilmentAction.getPersonalisation());
 
     emailFulfilmentRequest.setHeader(header);
     payload.setEmailFulfilment(emailFulfilment);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyEmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyEmailTemplateEndpoint.java
@@ -22,6 +22,7 @@ import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyEmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.EmailTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.repository.EmailTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveyEmailTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
@@ -51,8 +52,7 @@ public class FulfilmentSurveyEmailTemplateEndpoint {
   }
 
   @GetMapping
-  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
-  public List<String> getAllowedPackCodesBySurvey(
+  public List<EmailTemplateDto> getAllowedEmailTemplatesBySurvey(
       @RequestParam(value = "surveyId") UUID surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
@@ -67,8 +67,7 @@ public class FulfilmentSurveyEmailTemplateEndpoint {
         UserGroupAuthorisedActivityType.LIST_ALLOWED_EMAIL_TEMPLATES_ON_FULFILMENTS);
 
     return fulfilmentSurveyEmailTemplateRepository.findBySurvey(survey).stream()
-        .map(fsst -> fsst.getEmailTemplate().getPackCode())
-        .collect(Collectors.toList());
+        .map(fset -> new EmailTemplateDto(fset.getEmailTemplate())).toList();
   }
 
   @PostMapping

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType;
 import uk.gov.ons.ssdc.supporttool.model.dto.ui.AllowTemplateOnSurvey;
+import uk.gov.ons.ssdc.supporttool.model.dto.ui.SmsTemplateDto;
 import uk.gov.ons.ssdc.supporttool.model.repository.FulfilmentSurveySmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SmsTemplateRepository;
 import uk.gov.ons.ssdc.supporttool.model.repository.SurveyRepository;
@@ -51,8 +53,7 @@ public class FulfilmentSurveySmsTemplateEndpoint {
   }
 
   @GetMapping
-  // TODO: make this a bit more RESTful... but it does the job just fine; we don't really need a DTO
-  public List<String> getAllowedPackCodesBySurvey(
+  public List<SmsTemplateDto> getAllowedSmsTemplatesBySurvey(
       @RequestParam(value = "surveyId") UUID surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
     Survey survey =
@@ -67,8 +68,7 @@ public class FulfilmentSurveySmsTemplateEndpoint {
         UserGroupAuthorisedActivityType.LIST_ALLOWED_SMS_TEMPLATES_ON_FULFILMENTS);
 
     return fulfilmentSurveySmsTemplateRepository.findBySurvey(survey).stream()
-        .map(fsst -> fsst.getSmsTemplate().getPackCode())
-        .collect(Collectors.toList());
+        .map(fsst -> new SmsTemplateDto(fsst.getSmsTemplate())).toList();
   }
 
   @PostMapping

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/EmailFulfilment.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/EmailFulfilment.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.model.dto.rest;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 
@@ -9,4 +10,5 @@ public class EmailFulfilment {
   private String email;
   private String packCode;
   private Object uacMetadata;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/SmsFulfilment.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/rest/SmsFulfilment.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.supporttool.model.dto.rest;
 
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 
@@ -9,4 +10,5 @@ public class SmsFulfilment {
   private String phoneNumber;
   private String packCode;
   private Object uacMetadata;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailFulfilmentAction.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailFulfilmentAction.java
@@ -2,9 +2,12 @@ package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import lombok.Data;
 
+import java.util.Map;
+
 @Data
 public class EmailFulfilmentAction {
   private String packCode;
   private String email;
   private Object uacMetadata;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailTemplateDto.java
@@ -2,12 +2,24 @@ package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import java.util.UUID;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 
 @Data
+@NoArgsConstructor
 public class EmailTemplateDto {
   private String packCode;
   private String[] template;
   private UUID notifyTemplateId;
   private String description;
   private Object metadata;
+
+  public EmailTemplateDto(EmailTemplate emailTemplate) {
+    packCode = emailTemplate.getPackCode();
+    template = emailTemplate.getTemplate();
+    notifyTemplateId = emailTemplate.getNotifyTemplateId();
+    description = emailTemplate.getDescription();
+    metadata = emailTemplate.getMetadata();
+  }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsFulfilmentAction.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsFulfilmentAction.java
@@ -2,9 +2,12 @@ package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import lombok.Data;
 
+import java.util.Map;
+
 @Data
 public class SmsFulfilmentAction {
   private String packCode;
   private String phoneNumber;
   private Object uacMetadata;
+  private Map<String, String> personalisation;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
@@ -2,12 +2,23 @@ package uk.gov.ons.ssdc.supporttool.model.dto.ui;
 
 import java.util.UUID;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 
 @Data
+@NoArgsConstructor
 public class SmsTemplateDto {
   private String packCode;
   private String[] template;
   private UUID notifyTemplateId;
   private String description;
   private Object metadata;
+
+  public SmsTemplateDto(SmsTemplate smsTemplate) {
+    packCode = smsTemplate.getPackCode();
+    template = smsTemplate.getTemplate();
+    notifyTemplateId = smsTemplate.getNotifyTemplateId();
+    description = smsTemplate.getDescription();
+    metadata = smsTemplate.getMetadata();
+  }
 }

--- a/ui/src/AllowedEmailTemplatesOnActionRulesList.js
+++ b/ui/src/AllowedEmailTemplatesOnActionRulesList.js
@@ -19,15 +19,15 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getAllEmailTemplates,
-  getActionRuleEmailTemplates,
+  getAllEmailPackCodes,
+  getActionRuleEmailPackCodesForSurvey,
 } from "./Utils";
 
 class AllowedEmailTemplatesOnActionRulesList extends Component {
   state = {
     authorisedActivities: [],
-    actionRuleEmailTemplates: [],
-    allowableActionRuleEmailTemplates: [],
+    actionRuleEmailPackCodes: [],
+    allowableActionRuleEmailPackCodes: [],
     emailTemplateToAllow: "",
     emailTemplateValidationError: false,
     allowEmailTemplateError: "",
@@ -53,26 +53,26 @@ class AllowedEmailTemplatesOnActionRulesList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allEmailFulfilmentTemplates = await getAllEmailTemplates(
+    const allEmailFulfilmentPackCodes = await getAllEmailPackCodes(
       authorisedActivities
     );
 
-    const actionRuleEmailTemplates = await getActionRuleEmailTemplates(
+    const actionRuleEmailPackCodes = await getActionRuleEmailPackCodesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
 
-    let allowableActionRuleEmailTemplates = [];
+    let allowableActionRuleEmailPackCodes = [];
 
-    allEmailFulfilmentTemplates.forEach((packCode) => {
-      if (!actionRuleEmailTemplates.includes(packCode)) {
-        allowableActionRuleEmailTemplates.push(packCode);
+    allEmailFulfilmentPackCodes.forEach((packCode) => {
+      if (!actionRuleEmailPackCodes.includes(packCode)) {
+        allowableActionRuleEmailPackCodes.push(packCode);
       }
     });
 
     this.setState({
-      actionRuleEmailTemplates: actionRuleEmailTemplates,
-      allowableActionRuleEmailTemplates: allowableActionRuleEmailTemplates,
+      actionRuleEmailPackCodes: actionRuleEmailPackCodes,
+      allowableActionRuleEmailPackCodes: allowableActionRuleEmailPackCodes,
     });
   };
 
@@ -135,16 +135,16 @@ class AllowedEmailTemplatesOnActionRulesList extends Component {
 
   render() {
     const actionRuleEmailTemplateTableRows =
-      this.state.actionRuleEmailTemplates.map((emailTemplate) => (
-        <TableRow key={emailTemplate}>
+      this.state.actionRuleEmailPackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {emailTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));
 
     const actionRuleEmailTemplateMenuItems =
-      this.state.allowableActionRuleEmailTemplates.map((packCode) => (
+      this.state.allowableActionRuleEmailPackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>

--- a/ui/src/AllowedEmailTemplatesOnFulfilments.js
+++ b/ui/src/AllowedEmailTemplatesOnFulfilments.js
@@ -19,16 +19,16 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getAllEmailTemplates,
-  getEmailFulfilmentTemplates,
+  getAllEmailPackCodes,
+  getEmailFulfilmentTemplatesForSurvey,
 } from "./Utils";
 
 class AllowedEmailTemplatesOnFulfilments extends Component {
   state = {
     authorisedActivities: [],
     allowEmailFulfilmentTemplateDialogDisplayed: false,
-    emailFulfilmentTemplates: [],
-    allowableEmailFulfilmentTemplates: [],
+    emailFulfilmentPackCodes: [],
+    allowableEmailFulfilmentPackCodes: [],
     exportFileTemplateToAllow: "",
     exportFileTemplateValidationError: false,
     allowExportFileTemplateError: "",
@@ -54,26 +54,30 @@ class AllowedEmailTemplatesOnFulfilments extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allEmailFulfilmentTemplates = await getAllEmailTemplates(
+    const allEmailFulfilmentPackCodes = await getAllEmailPackCodes(
       authorisedActivities
     );
 
-    const emailFulfilmentTemplates = await getEmailFulfilmentTemplates(
+    const emailFulfilmentTemplates = await getEmailFulfilmentTemplatesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
 
-    let allowableEmailFulfilmentTemplates = [];
+    const emailFulfilmentPackCodes = emailFulfilmentTemplates.map(
+      (template) => template.packCode
+    );
 
-    allEmailFulfilmentTemplates.forEach((packCode) => {
-      if (!emailFulfilmentTemplates.includes(packCode)) {
-        allowableEmailFulfilmentTemplates.push(packCode);
+    let allowableEmailFulfilmentPackCodes = [];
+
+    allEmailFulfilmentPackCodes.forEach((packCode) => {
+      if (!emailFulfilmentPackCodes.includes(packCode)) {
+        allowableEmailFulfilmentPackCodes.push(packCode);
       }
     });
 
     this.setState({
-      emailFulfilmentTemplates: emailFulfilmentTemplates,
-      allowableEmailFulfilmentTemplates: allowableEmailFulfilmentTemplates,
+      emailFulfilmentPackCodes: emailFulfilmentPackCodes,
+      allowableEmailFulfilmentPackCodes: allowableEmailFulfilmentPackCodes,
     });
   };
 
@@ -136,16 +140,16 @@ class AllowedEmailTemplatesOnFulfilments extends Component {
 
   render() {
     const emailFulfilmentTemplateTableRows =
-      this.state.emailFulfilmentTemplates.map((emailTemplate) => (
-        <TableRow key={emailTemplate}>
+      this.state.emailFulfilmentPackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {emailTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));
 
     const emailFulfilmentTemplateMenuItems =
-      this.state.allowableEmailFulfilmentTemplates.map((packCode) => (
+      this.state.allowableEmailFulfilmentPackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>

--- a/ui/src/AllowedExportFileTemplatesActionRulesList.js
+++ b/ui/src/AllowedExportFileTemplatesActionRulesList.js
@@ -19,14 +19,14 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getActionRuleExportFileTemplates,
-  getAllExportFileTemplates,
+  getActionRuleExportFilePackCodesForSurvey,
+  getAllExportFilePackCodes,
 } from "./Utils";
 
 class AllowedExportFileTemplatesActionRulesList extends Component {
   state = {
-    actionRuleExportFileTemplates: [],
-    allowableActionRuleExportFileTemplates: [],
+    actionRuleExportFilePackCodes: [],
+    allowableActionRuleExportFilePackCodes: [],
     authorisedActivities: [],
     allowActionRuleExportFileTemplateDialogDisplayed: false,
     exportFileTemplateToAllow: "",
@@ -54,28 +54,28 @@ class AllowedExportFileTemplatesActionRulesList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allExportFileFulfilmentTemplates = await getAllExportFileTemplates(
+    const allExportFileFulfilmentTemplates = await getAllExportFilePackCodes(
       authorisedActivities
     );
 
-    const actionRuleExportFileTemplates =
-      await getActionRuleExportFileTemplates(
+    const actionRuleExportFilePackCodes =
+      await getActionRuleExportFilePackCodesForSurvey(
         authorisedActivities,
         this.props.surveyId
       );
 
-    let allowableActionRuleExportFileTemplates = [];
+    let allowableActionRuleExportFilePackCodes = [];
 
     allExportFileFulfilmentTemplates.forEach((packCode) => {
-      if (!actionRuleExportFileTemplates.includes(packCode)) {
-        allowableActionRuleExportFileTemplates.push(packCode);
+      if (!actionRuleExportFilePackCodes.includes(packCode)) {
+        allowableActionRuleExportFilePackCodes.push(packCode);
       }
     });
 
     this.setState({
-      allowableActionRuleExportFileTemplates:
-        allowableActionRuleExportFileTemplates,
-      actionRuleExportFileTemplates: actionRuleExportFileTemplates,
+      allowableActionRuleExportFilePackCodes:
+        allowableActionRuleExportFilePackCodes,
+      actionRuleExportFilePackCodes: actionRuleExportFilePackCodes,
     });
   };
 
@@ -140,16 +140,16 @@ class AllowedExportFileTemplatesActionRulesList extends Component {
 
   render() {
     const actionRuleExportFileTemplateTableRows =
-      this.state.actionRuleExportFileTemplates.map((exportFileTemplate) => (
-        <TableRow key={exportFileTemplate}>
+      this.state.actionRuleExportFilePackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {exportFileTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));
 
     const actionRuleExportFileTemplateMenuItems =
-      this.state.allowableActionRuleExportFileTemplates.map((packCode) => (
+      this.state.allowableActionRuleExportFilePackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>

--- a/ui/src/AllowedExportFileTemplatesOnFulfilmentsList.js
+++ b/ui/src/AllowedExportFileTemplatesOnFulfilmentsList.js
@@ -19,8 +19,8 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getAllExportFileTemplates,
-  getFulfilmentExportFileTemplates,
+  getAllExportFilePackCodes,
+  getFulfilmentExportFileTemplatesForSurvey,
 } from "./Utils";
 
 class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
@@ -55,12 +55,12 @@ class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allExportFileFulfilmentPackCodes = await getAllExportFileTemplates(
+    const allExportFileFulfilmentPackCodes = await getAllExportFilePackCodes(
       authorisedActivities
     );
 
     const fulfilmentExportFileTemplates =
-      await getFulfilmentExportFileTemplates(
+      await getFulfilmentExportFileTemplatesForSurvey(
         authorisedActivities,
         this.props.surveyId
       );
@@ -150,10 +150,10 @@ class AllowedExportFileTemplatesOnFulfilmentsList extends Component {
       ));
 
     const fulfilmentExportFileTemplateTableRows =
-      this.state.fulfilmentExportFilePackCodes.map((exportFileTemplate) => (
-        <TableRow key={exportFileTemplate}>
+      this.state.fulfilmentExportFilePackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {exportFileTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));

--- a/ui/src/AllowedSMSTemplatesActionRulesList.js
+++ b/ui/src/AllowedSMSTemplatesActionRulesList.js
@@ -19,15 +19,15 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getAllSmsTemplates,
-  getActionRuleSmsTemplates,
+  getAllSmsPackCodes,
+  getActionRuleSmsPackCodesForSurvey,
 } from "./Utils";
 
 class AllowedSMSTemplatesActionRulesList extends Component {
   state = {
     authorisedActivities: [],
-    actionRuleSmsTemplates: [],
-    allowableActionRuleSmsTemplates: [],
+    actionRuleSmsPackCodes: [],
+    allowableActionRuleSmsPackCodes: [],
     smsTemplateToAllow: "",
     smsTemplateValidationError: false,
     allowSmsTemplateError: "",
@@ -53,26 +53,26 @@ class AllowedSMSTemplatesActionRulesList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allSmsFulfilmentTemplates = await getAllSmsTemplates(
+    const allSmsFulfilmentPackCodes = await getAllSmsPackCodes(
       authorisedActivities
     );
 
-    const actionRuleSmsTemplates = await getActionRuleSmsTemplates(
+    const actionRuleSmsPackCodes = await getActionRuleSmsPackCodesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
 
-    let allowableActionRuleSmsTemplates = [];
+    let allowableActionRuleSmsPackCodes = [];
 
-    allSmsFulfilmentTemplates.forEach((packCode) => {
-      if (!actionRuleSmsTemplates.includes(packCode)) {
-        allowableActionRuleSmsTemplates.push(packCode);
+    allSmsFulfilmentPackCodes.forEach((packCode) => {
+      if (!actionRuleSmsPackCodes.includes(packCode)) {
+        allowableActionRuleSmsPackCodes.push(packCode);
       }
     });
 
     this.setState({
-      allowableActionRuleSmsTemplates: allowableActionRuleSmsTemplates,
-      actionRuleSmsTemplates: actionRuleSmsTemplates,
+      allowableActionRuleSmsPackCodes: allowableActionRuleSmsPackCodes,
+      actionRuleSmsPackCodes: actionRuleSmsPackCodes,
     });
   };
 
@@ -137,16 +137,16 @@ class AllowedSMSTemplatesActionRulesList extends Component {
 
   render() {
     const actionRuleSmsTemplateTableRows =
-      this.state.actionRuleSmsTemplates.map((smsTemplate) => (
-        <TableRow key={smsTemplate}>
+      this.state.actionRuleSmsPackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {smsTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));
 
     const actionRuleSmsTemplateMenuItems =
-      this.state.allowableActionRuleSmsTemplates.map((packCode) => (
+      this.state.allowableActionRuleSmsPackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>

--- a/ui/src/AllowedSMSTemplatesOnFulfilmentsList.js
+++ b/ui/src/AllowedSMSTemplatesOnFulfilmentsList.js
@@ -19,16 +19,16 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import {
   getAuthorisedActivities,
-  getAllSmsTemplates,
-  getSmsFulfilmentTemplates,
+  getAllSmsPackCodes,
+  getSmsFulfilmentTemplatesForSurvey,
 } from "./Utils";
 
 class AllowedSMSTemplatesOnFulfilmentsList extends Component {
   state = {
     authorisedActivities: [],
     allowSmsFulfilmentTemplateDialogDisplayed: false,
-    smsFulfilmentTemplates: [],
-    allowableSmsFulfilmentTemplates: [],
+    smsFulfilmentPackCodes: [],
+    allowableSmsFulfilmentPackCodes: [],
     smsTemplateToAllow: "",
     exportFileTemplateValidationError: false,
     allowExportFileTemplateError: "",
@@ -54,26 +54,29 @@ class AllowedSMSTemplatesOnFulfilmentsList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    const allSmsFulfilmentTemplates = await getAllSmsTemplates(
+    const allSmsFulfilmentPackCodes = await getAllSmsPackCodes(
       authorisedActivities
     );
 
-    const smsFulfilmentTemplates = await getSmsFulfilmentTemplates(
+    const smsFulfilmentTemplates = await getSmsFulfilmentTemplatesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
+    const smsFulfilmentPackCodes = smsFulfilmentTemplates.map(
+      (template) => template.packCode
+    );
 
-    let allowableSmsFulfilmentTemplates = [];
+    let allowableSmsFulfilmentPackCodes = [];
 
-    allSmsFulfilmentTemplates.forEach((packCode) => {
-      if (!smsFulfilmentTemplates.includes(packCode)) {
-        allowableSmsFulfilmentTemplates.push(packCode);
+    allSmsFulfilmentPackCodes.forEach((packCode) => {
+      if (!smsFulfilmentPackCodes.includes(packCode)) {
+        allowableSmsFulfilmentPackCodes.push(packCode);
       }
     });
 
     this.setState({
-      smsFulfilmentTemplates: smsFulfilmentTemplates,
-      allowableSmsFulfilmentTemplates: allowableSmsFulfilmentTemplates,
+      smsFulfilmentPackCodes: smsFulfilmentPackCodes,
+      allowableSmsFulfilmentPackCodes: allowableSmsFulfilmentPackCodes,
     });
   };
 
@@ -136,16 +139,16 @@ class AllowedSMSTemplatesOnFulfilmentsList extends Component {
 
   render() {
     const smsFulfilmentTemplateTableRows =
-      this.state.smsFulfilmentTemplates.map((smsTemplate) => (
-        <TableRow key={smsTemplate}>
+      this.state.smsFulfilmentPackCodes.map((packCode) => (
+        <TableRow key={packCode}>
           <TableCell component="th" scope="row">
-            {smsTemplate}
+            {packCode}
           </TableCell>
         </TableRow>
       ));
 
     const smsFulfilmentTemplateMenuItems =
-      this.state.allowableSmsFulfilmentTemplates.map((packCode) => (
+      this.state.allowableSmsFulfilmentPackCodes.map((packCode) => (
         <MenuItem key={packCode} value={packCode}>
           {packCode}
         </MenuItem>

--- a/ui/src/CaseDetails.js
+++ b/ui/src/CaseDetails.js
@@ -258,14 +258,6 @@ class CaseDetails extends Component {
                       "CREATE_CASE_INVALID_CASE"
                     ) && <InvalidCase caseId={this.props.caseId} />}
                     {this.state.authorisedActivities.includes(
-                      "CREATE_CASE_EXPORT_FILE_FULFILMENT"
-                    ) && (
-                      <PrintFulfilment
-                        caseId={this.props.caseId}
-                        surveyId={this.props.surveyId}
-                      />
-                    )}
-                    {this.state.authorisedActivities.includes(
                       "UPDATE_SAMPLE"
                     ) && (
                       <SampleData
@@ -277,6 +269,14 @@ class CaseDetails extends Component {
                       "UPDATE_SAMPLE_SENSITIVE"
                     ) && (
                       <SensitiveData
+                        caseId={this.props.caseId}
+                        surveyId={this.props.surveyId}
+                      />
+                    )}
+                    {this.state.authorisedActivities.includes(
+                      "CREATE_CASE_EXPORT_FILE_FULFILMENT"
+                    ) && (
+                      <PrintFulfilment
                         caseId={this.props.caseId}
                         surveyId={this.props.surveyId}
                       />

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -20,9 +20,9 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import SampleUpload from "./SampleUpload";
 import {
-  getActionRuleExportFileTemplates,
-  getActionRuleSmsTemplates,
-  getActionRuleEmailTemplates,
+  getActionRuleExportFilePackCodesForSurvey,
+  getActionRuleSmsPackCodesForSurvey,
+  getActionRuleEmailPackCodesForSurvey,
   getSensitiveSampleColumns,
 } from "./Utils";
 import { Link } from "react-router-dom";
@@ -138,7 +138,7 @@ class CollectionExerciseDetails extends Component {
     )
       return;
 
-    const packCodes = await getActionRuleExportFileTemplates(
+    const packCodes = await getActionRuleExportFilePackCodesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
@@ -153,7 +153,7 @@ class CollectionExerciseDetails extends Component {
     )
       return;
 
-    const packCodes = await getActionRuleSmsTemplates(
+    const packCodes = await getActionRuleSmsPackCodesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
@@ -168,7 +168,7 @@ class CollectionExerciseDetails extends Component {
     )
       return;
 
-    const packCodes = await getActionRuleEmailTemplates(
+    const packCodes = await getActionRuleEmailPackCodesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );

--- a/ui/src/ExportFileTemplatesList.js
+++ b/ui/src/ExportFileTemplatesList.js
@@ -79,15 +79,6 @@ class ExportFileTemplateList extends Component {
     });
   };
 
-  getExportFileTemplates = async (authorisedActivities) => {
-    if (!authorisedActivities.includes("LIST_EXPORT_FILE_TEMPLATES")) return;
-
-    const response = await fetch("/api/exportFileTemplates");
-    const templateJson = await response.json();
-
-    this.setState({ exportFileTemplates: templateJson });
-  };
-
   openExportFileTemplateDialog = () => {
     this.createExportFileTemplateInProgress = false;
 
@@ -118,7 +109,7 @@ class ExportFileTemplateList extends Component {
     this.refresh;
   };
 
-  onexportFileDestinationChange = (event) => {
+  onExportFileDestinationChange = (event) => {
     this.setState({
       exportFileDestination: event.target.value,
       exportFileDestinationValidationError: false,
@@ -374,7 +365,7 @@ class ExportFileTemplateList extends Component {
                 >
                   <InputLabel>Export File Destination</InputLabel>
                   <Select
-                    onChange={this.onexportFileDestinationChange}
+                    onChange={this.onExportFileDestinationChange}
                     value={this.state.exportFileDestination}
                     error={this.state.exportFileDestinationValidationError}
                   >

--- a/ui/src/FulfilmentPersonalisationForm.js
+++ b/ui/src/FulfilmentPersonalisationForm.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+import { FormControl, TextField } from "@material-ui/core";
+
+class FulfilmentPersonalisationForm extends Component {
+  getTemplateRequestPersonalisationKeys = (templateKeys) => {
+    return templateKeys
+      .filter((templateKey) => templateKey.startsWith("__request__."))
+      .map((templateKey) => templateKey.replace("__request__.", ""));
+  };
+
+  render() {
+    let selectedTemplate = this.props.template;
+    let requestTemplateKeys = [];
+    if (selectedTemplate !== "") {
+      requestTemplateKeys = this.getTemplateRequestPersonalisationKeys(
+        this.props.template.template
+      );
+    }
+
+    let personalisationFormItems = requestTemplateKeys.map(
+      (personalisationKey) => (
+        <FormControl fullWidth={true} key={personalisationKey}>
+          <TextField
+            label={personalisationKey}
+            id={"personalisationKey-" + personalisationKey}
+            name={personalisationKey}
+            onChange={this.props.onPersonalisationValueChange}
+          />
+        </FormControl>
+      )
+    );
+
+    return (
+      <>
+        {requestTemplateKeys.length > 0 && personalisationFormItems && (
+          <fieldset>
+            <label>Optional Request Personalisation</label>
+            {personalisationFormItems}
+          </fieldset>
+        )}
+      </>
+    );
+  }
+}
+
+export default FulfilmentPersonalisationForm;

--- a/ui/src/SmsFulfilment.js
+++ b/ui/src/SmsFulfilment.js
@@ -9,20 +9,23 @@ import {
   Select,
   TextField,
 } from "@material-ui/core";
-import { getSmsFulfilmentTemplates } from "./Utils";
+import { getSmsFulfilmentTemplatesForSurvey } from "./Utils";
+import FulfilmentPersonalisationForm from "./FulfilmentPersonalisationForm";
 
 class SmsFulfilment extends Component {
   state = {
-    packCode: "",
+    selectedTemplate: "",
     allowableSmsFulfilmentTemplates: [],
-    packCodeValidationError: false,
-    packCodeValidationErrorDesc: "",
+    templateValidationError: false,
+    templateValidationErrorDesc: "",
     smsUacQidMetadataValidationError: false,
     showDialog: false,
     phoneNumber: "",
     newValueValidationError: "",
     validationError: false,
     newSmsUacQidMetadata: "",
+    personalisationFormItems: "",
+    personalisationValues: null,
   };
 
   componentDidMount() {
@@ -59,13 +62,15 @@ class SmsFulfilment extends Component {
 
   closeDialog = () => {
     this.setState({
-      packCode: "",
-      packCodeValidationError: false,
+      selectedTemplate: "",
+      templateValidationError: false,
       showDialog: false,
       newValueValidationError: "",
       phoneNumber: "",
       validationError: false,
       newSmsUacQidMetadata: "",
+      personalisationFormItems: "",
+      personalisationValues: null,
     });
   };
 
@@ -83,7 +88,7 @@ class SmsFulfilment extends Component {
     )
       return;
 
-    const fulfilmentSmsTemplates = await getSmsFulfilmentTemplates(
+    const fulfilmentSmsTemplates = await getSmsFulfilmentTemplatesForSurvey(
       authorisedActivities,
       this.props.surveyId
     );
@@ -94,7 +99,7 @@ class SmsFulfilment extends Component {
   };
 
   onSmsTemplateChange = (event) => {
-    this.setState({ packCode: event.target.value });
+    this.setState({ selectedTemplate: event.target.value });
   };
 
   onNewActionRuleSmsUacQidMetadataChange = (event) => {
@@ -113,9 +118,9 @@ class SmsFulfilment extends Component {
 
     let validationFailed = false;
 
-    if (!this.state.packCode) {
+    if (!this.state.selectedTemplate) {
       this.setState({
-        packCodeValidationError: true,
+        templateValidationError: true,
       });
       validationFailed = true;
     }
@@ -149,9 +154,10 @@ class SmsFulfilment extends Component {
     }
 
     const smsFulfilment = {
-      packCode: this.state.packCode,
+      packCode: this.state.selectedTemplate.packCode,
       phoneNumber: this.state.phoneNumber,
       uacMetadata: uacMetadataJson,
+      personalisation: this.state.personalisationValues,
     };
 
     const response = await fetch(
@@ -176,11 +182,19 @@ class SmsFulfilment extends Component {
     }
   };
 
+  onPersonalisationValueChange = (event) => {
+    let updatedPersonalisationValues = this.state.personalisationValues
+      ? this.state.personalisationValues
+      : {};
+    updatedPersonalisationValues[event.target.name] = event.target.value;
+    this.setState({ personalisationValues: updatedPersonalisationValues });
+  };
+
   render() {
     const fulfilmentSmsTemplateMenuItems =
-      this.state.allowableSmsFulfilmentTemplates.map((packCode) => (
-        <MenuItem key={packCode} value={packCode}>
-          {packCode}
+      this.state.allowableSmsFulfilmentTemplates.map((template) => (
+        <MenuItem key={template.packCode} value={template}>
+          {template.packCode}
         </MenuItem>
       ));
 
@@ -200,8 +214,8 @@ class SmsFulfilment extends Component {
                 <InputLabel>SMS Template</InputLabel>
                 <Select
                   onChange={this.onSmsTemplateChange}
-                  value={this.state.packCode}
-                  error={this.state.packCodeValidationError}
+                  value={this.state.selectedTemplate}
+                  error={this.state.templateValidationError}
                 >
                   {fulfilmentSmsTemplateMenuItems}
                 </Select>
@@ -225,6 +239,14 @@ class SmsFulfilment extends Component {
                   value={this.state.newSmsUacQidMetadata}
                 />
               </FormControl>
+              {this.state.showDialog && (
+                <FulfilmentPersonalisationForm
+                  template={this.state.selectedTemplate}
+                  onPersonalisationValueChange={
+                    this.onPersonalisationValueChange
+                  }
+                />
+              )}
             </div>
             <div style={{ marginTop: 10 }}>
               <Button

--- a/ui/src/Utils.js
+++ b/ui/src/Utils.js
@@ -1,4 +1,4 @@
-export const getAllExportFileTemplates = async (authorisedActivities) => {
+export const getAllExportFilePackCodes = async (authorisedActivities) => {
   // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
   if (!authorisedActivities.includes("LIST_EXPORT_FILE_TEMPLATES")) return [];
 
@@ -10,7 +10,7 @@ export const getAllExportFileTemplates = async (authorisedActivities) => {
   return templatePackCodes;
 };
 
-export const getAllSmsTemplates = async (authorisedActivities) => {
+export const getAllSmsPackCodes = async (authorisedActivities) => {
   // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
   if (!authorisedActivities.includes("LIST_SMS_TEMPLATES")) return [];
 
@@ -22,7 +22,7 @@ export const getAllSmsTemplates = async (authorisedActivities) => {
   return templatePackCodes;
 };
 
-export const getAllEmailTemplates = async (authorisedActivities) => {
+export const getAllEmailPackCodes = async (authorisedActivities) => {
   // The caller should probably check this, but it's here as a belt-and-braces in case of badly behaved programmers
   if (!authorisedActivities.includes("LIST_EMAIL_TEMPLATES")) return [];
 
@@ -34,7 +34,7 @@ export const getAllEmailTemplates = async (authorisedActivities) => {
   return templatePackCodes;
 };
 
-export const getFulfilmentExportFileTemplates = async (
+export const getFulfilmentExportFileTemplatesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {
@@ -53,7 +53,7 @@ export const getFulfilmentExportFileTemplates = async (
   return fulfilmentExportFileTemplates;
 };
 
-export const getSmsFulfilmentTemplates = async (
+export const getSmsFulfilmentTemplatesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {
@@ -71,7 +71,7 @@ export const getSmsFulfilmentTemplates = async (
   return smsFulfilmentTemplatesJson;
 };
 
-export const getEmailFulfilmentTemplates = async (
+export const getEmailFulfilmentTemplatesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {
@@ -91,7 +91,7 @@ export const getEmailFulfilmentTemplates = async (
   return emailFulfilmentTemplatesJson;
 };
 
-export const getActionRuleExportFileTemplates = async (
+export const getActionRuleExportFilePackCodesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {
@@ -111,7 +111,7 @@ export const getActionRuleExportFileTemplates = async (
   return exportFileTemplatesJson;
 };
 
-export const getActionRuleSmsTemplates = async (
+export const getActionRuleSmsPackCodesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {
@@ -129,7 +129,7 @@ export const getActionRuleSmsTemplates = async (
   return smsTemplatesJson;
 };
 
-export const getActionRuleEmailTemplates = async (
+export const getActionRuleEmailPackCodesForSurvey = async (
   authorisedActivities,
   surveyId
 ) => {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SMS and email fulfilments will now support added personalisation values on the request, so the support tool UI needs to support it.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->-
- Add dynamic personalisation form section to SMS and email fulfilment request forms 
- Pass personalisation through to notify request in the back end
- Factor out personalisation form as component
- Sort out template/packCode naming confusion in JS

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run the linked branches, create SMS and email templates with and without `__request__.` prefixed personalisation fields in the template. When you request an SMS/email fulfilment on the case, when selecting a template which includes these fields, the form should update to include those optional personalisation fields.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/8DGOfdJx/3246-personalisation-on-sms-and-email-fulfilments-8
