### PR TITLE
check for duplicate columns in templates email & sms

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
@@ -1,6 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -56,15 +59,7 @@ public class EmailTemplateEndpoint {
     userIdentity.checkGlobalUserPermission(
         userEmail, UserGroupAuthorisedActivityType.CREATE_EMAIL_TEMPLATE);
 
-    emailTemplateRepository
-        .findAll()
-        .forEach(
-            emailTemplate -> {
-              if (emailTemplate.getPackCode().equalsIgnoreCase(emailTemplateDto.getPackCode())) {
-                throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Pack code already exists");
-              }
-            });
+    validateEmailTemplate(emailTemplateDto);
 
     EmailTemplate emailTemplate = new EmailTemplate();
     emailTemplate.setTemplate(emailTemplateDto.getTemplate());
@@ -76,5 +71,24 @@ public class EmailTemplateEndpoint {
     emailTemplateRepository.saveAndFlush(emailTemplate);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  private void validateEmailTemplate(EmailTemplateDto emailTemplateDto) {
+
+    emailTemplateRepository
+        .findAll()
+        .forEach(
+            emailTemplate -> {
+              if (emailTemplate.getPackCode().equalsIgnoreCase(emailTemplateDto.getPackCode())) {
+                throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "Pack code already exists");
+              }
+            });
+
+    Set<String> templateSet = new HashSet<>(Arrays.asList(emailTemplateDto.getTemplate()));
+    if (templateSet.size() != emailTemplateDto.getTemplate().length) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
@@ -75,6 +75,12 @@ public class EmailTemplateEndpoint {
 
   private void validateEmailTemplate(EmailTemplateDto emailTemplateDto) {
 
+    Set<String> templateSet = new HashSet<>(Arrays.asList(emailTemplateDto.getTemplate()));
+    if (templateSet.size() != emailTemplateDto.getTemplate().length) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
+    }
+
     emailTemplateRepository
         .findAll()
         .forEach(
@@ -84,11 +90,5 @@ public class EmailTemplateEndpoint {
                     HttpStatus.BAD_REQUEST, "Pack code already exists");
               }
             });
-
-    Set<String> templateSet = new HashSet<>(Arrays.asList(emailTemplateDto.getTemplate()));
-    if (templateSet.size() != emailTemplateDto.getTemplate().length) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
-    }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -1,6 +1,9 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -56,15 +59,7 @@ public class SmsTemplateEndpoint {
     userIdentity.checkGlobalUserPermission(
         userEmail, UserGroupAuthorisedActivityType.CREATE_SMS_TEMPLATE);
 
-    smsTemplateRepository
-        .findAll()
-        .forEach(
-            smsTemplate -> {
-              if (smsTemplate.getPackCode().equalsIgnoreCase(smsTemplateDto.getPackCode())) {
-                throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Pack code already exists");
-              }
-            });
+    validateTemplate(smsTemplateDto);
 
     SmsTemplate smsTemplate = new SmsTemplate();
     smsTemplate.setTemplate(smsTemplateDto.getTemplate());
@@ -76,5 +71,23 @@ public class SmsTemplateEndpoint {
     smsTemplateRepository.saveAndFlush(smsTemplate);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  private void validateTemplate(SmsTemplateDto smsTemplateDto) {
+    smsTemplateRepository
+        .findAll()
+        .forEach(
+            smsTemplate -> {
+              if (smsTemplate.getPackCode().equalsIgnoreCase(smsTemplateDto.getPackCode())) {
+                throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "Pack code already exists");
+              }
+            });
+
+    Set<String> templateSet = new HashSet<>(Arrays.asList(smsTemplateDto.getTemplate()));
+    if (templateSet.size() != smsTemplateDto.getTemplate().length) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -74,6 +74,12 @@ public class SmsTemplateEndpoint {
   }
 
   private void validateTemplate(SmsTemplateDto smsTemplateDto) {
+    Set<String> templateSet = new HashSet<>(Arrays.asList(smsTemplateDto.getTemplate()));
+    if (templateSet.size() != smsTemplateDto.getTemplate().length) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
+    }
+
     smsTemplateRepository
         .findAll()
         .forEach(
@@ -83,11 +89,5 @@ public class SmsTemplateEndpoint {
                     HttpStatus.BAD_REQUEST, "Pack code already exists");
               }
             });
-
-    Set<String> templateSet = new HashSet<>(Arrays.asList(smsTemplateDto.getTemplate()));
-    if (templateSet.size() != smsTemplateDto.getTemplate().length) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Template cannot have duplicate columns");
-    }
   }
 }

--- a/ui/src/EmailTemplateList.js
+++ b/ui/src/EmailTemplateList.js
@@ -190,24 +190,29 @@ class EmailTemplateList extends Component {
       }
     }
 
-
-
     if (!this.state.template.trim()) {
       this.setState({ templateValidationError: true });
       failedValidation = true;
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length;
+        const hasDuplicateTemplateColumns =
+          new Set(parsedJson).size !== parsedJson.length;
         if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
-          this.setState({ templateValidationErrorMessage: "Email template must be JSON array with one or more unique elements" });
+          this.setState({
+            templateValidationErrorMessage:
+              "Email template must be JSON array with one or more unique elements",
+          });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
-        this.setState({ templateValidationErrorMessage: "Email template must be JSON array with one or more unique elements" });
+        this.setState({
+          templateValidationErrorMessage:
+            "Email template must be JSON array with one or more unique elements",
+        });
       }
     }
 

--- a/ui/src/EmailTemplateList.js
+++ b/ui/src/EmailTemplateList.js
@@ -202,12 +202,12 @@ class EmailTemplateList extends Component {
         if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
-          this.setState({ templateValidationErrorMessage: "email template must be JSON array with one or more unique elements" });
+          this.setState({ templateValidationErrorMessage: "Email template must be JSON array with one or more unique elements" });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
-        this.setState({ templateValidationErrorMessage: "email template must be JSON array with one or more unique elements" });
+        this.setState({ templateValidationErrorMessage: "Email template must be JSON array with one or more unique elements" });
       }
     }
 

--- a/ui/src/EmailTemplateList.js
+++ b/ui/src/EmailTemplateList.js
@@ -30,6 +30,7 @@ class EmailTemplateList extends Component {
     packCodeValidationError: "",
     descriptionValidationError: false,
     templateValidationError: false,
+    templateValidationErrorMessage: "",
     newTemplateMetadataValidationError: false,
     notifyTemplateIdValidationError: false,
     notifyTemplateIdErrorMessage: "",
@@ -73,6 +74,7 @@ class EmailTemplateList extends Component {
       packCodeValidationError: false,
       descriptionValidationError: false,
       templateValidationError: false,
+      templateValidationErrorMessage: "",
       newTemplateMetadataValidationError: false,
       notifyTemplateIdValidationError: false,
       createEmailTemplateDialogDisplayed: true,
@@ -188,19 +190,24 @@ class EmailTemplateList extends Component {
       }
     }
 
+
+
     if (!this.state.template.trim()) {
       this.setState({ templateValidationError: true });
       failedValidation = true;
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        if (!Array.isArray(parsedJson)) {
+        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length;
+        if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
+          this.setState({ templateValidationErrorMessage: "email template must be JSON array with one or more unique elements" });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
+        this.setState({ templateValidationErrorMessage: "email template must be JSON array with one or more unique elements" });
       }
     }
 
@@ -350,6 +357,7 @@ class EmailTemplateList extends Component {
                   label="Template"
                   onChange={this.onTemplateChange}
                   value={this.state.template}
+                  helperText={this.state.templateValidationErrorMessage}
                 />
                 <TextField
                   fullWidth={true}

--- a/ui/src/SmsTemplatesList.js
+++ b/ui/src/SmsTemplatesList.js
@@ -160,12 +160,12 @@ class SmsTemplatesList extends Component {
         if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
-          this.setState({ templateValidationErrorMessage: "sms template must be JSON array with one or more unique elements" });
+          this.setState({ templateValidationErrorMessage: "SMS template must be JSON array with one or more unique elements" });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
-        this.setState({ templateValidationErrorMessage: "sms template must be JSON array with one or more unique elements" });
+        this.setState({ templateValidationErrorMessage: "SMS template must be JSON array with one or more unique elements" });
 
       }
     }

--- a/ui/src/SmsTemplatesList.js
+++ b/ui/src/SmsTemplatesList.js
@@ -156,17 +156,23 @@ class SmsTemplatesList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length;
+        const hasDuplicateTemplateColumns =
+          new Set(parsedJson).size !== parsedJson.length;
         if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
-          this.setState({ templateValidationErrorMessage: "SMS template must be JSON array with one or more unique elements" });
+          this.setState({
+            templateValidationErrorMessage:
+              "SMS template must be JSON array with one or more unique elements",
+          });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
-        this.setState({ templateValidationErrorMessage: "SMS template must be JSON array with one or more unique elements" });
-
+        this.setState({
+          templateValidationErrorMessage:
+            "SMS template must be JSON array with one or more unique elements",
+        });
       }
     }
 

--- a/ui/src/SmsTemplatesList.js
+++ b/ui/src/SmsTemplatesList.js
@@ -30,6 +30,7 @@ class SmsTemplatesList extends Component {
     packCodeValidationError: false,
     descriptionValidationError: false,
     templateValidationError: false,
+    templateValidationErrorMessage: "",
     newTemplateMetadataValidationError: false,
     notifyTemplateIdValidationError: false,
     notifyTemplateIdErrorMessage: "",
@@ -77,6 +78,7 @@ class SmsTemplatesList extends Component {
       packCodeValidationError: false,
       descriptionValidationError: false,
       templateValidationError: false,
+      templateValidationErrorMessage: "",
       newTemplateMetadataValidationError: false,
       notifyTemplateIdValidationError: false,
       createSmsTemplateDialogDisplayed: true,
@@ -154,13 +156,17 @@ class SmsTemplatesList extends Component {
     } else {
       try {
         const parsedJson = JSON.parse(this.state.template);
-        if (!Array.isArray(parsedJson)) {
+        const hasDuplicateTemplateColumns = new Set(parsedJson).size !== parsedJson.length;
+        if (!Array.isArray(parsedJson) || hasDuplicateTemplateColumns) {
           this.setState({ templateValidationError: true });
           failedValidation = true;
+          this.setState({ templateValidationErrorMessage: "sms template must be JSON array with one or more unique elements" });
         }
       } catch (err) {
         this.setState({ templateValidationError: true });
         failedValidation = true;
+        this.setState({ templateValidationErrorMessage: "sms template must be JSON array with one or more unique elements" });
+
       }
     }
 
@@ -353,6 +359,7 @@ class SmsTemplatesList extends Component {
                   label="Template"
                   onChange={this.onTemplateChange}
                   value={this.state.template}
+                  helperText={this.state.templateValidationErrorMessage}
                 />
                 <TextField
                   fullWidth={true}


### PR DESCRIPTION
# Motivation and Context
Stop users adding templates with duplicate columns

# What has changed
Checks for this in API and frontend.

# How to test?
Frontend should stop you creating an email or SMS with duplication.
To test the API you'll have to hack out the frontend code.

# Links
https://trello.com/c/ji0gpoDj/3335-support-tool-prevent-duplicate-columns-for-sms-email-templates-3