### PR TITLE
update all email lookup to be case insensitive

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
@@ -50,7 +50,7 @@ public class AuthorisationEndpoint {
       @RequestParam(required = false, value = "surveyId") Optional<UUID> surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
 
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return Set.of(UserGroupAuthorisedActivityType.values());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
@@ -56,7 +56,7 @@ public class AuthorisationEndpoint {
       return Set.of(UserGroupAuthorisedActivityType.values());
     }
 
-    Optional<User> userOpt = userRepository.findByEmail(userEmail);
+    Optional<User> userOpt = userRepository.findByEmailIgnoreCase(userEmail);
 
     if (!userOpt.isPresent()) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User not known to RM");

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
@@ -67,7 +67,7 @@ public class UserGroupEndpoint {
   @GetMapping("/thisUserAdminGroups")
   public List<UserGroupDto> getUserAdminGroups(
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-    return userGroupAdminRepository.findByUserEmail(userEmail).stream()
+    return userGroupAdminRepository.findByUserEmailIgnoreCase(userEmail).stream()
         .map(UserGroupAdmin::getGroup)
         .map(this::mapDto)
         .collect(Collectors.toList());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupEndpoint.java
@@ -48,7 +48,7 @@ public class UserGroupEndpoint {
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
     if (group.getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       // If you're not admin of this group, you have to be super user
       userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
     }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
@@ -72,7 +72,7 @@ public class UserGroupMemberEndpoint {
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
     if (group.getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       // If you're not admin of this group, you have to be super user
       userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
     }
@@ -93,7 +93,7 @@ public class UserGroupMemberEndpoint {
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Group not found"));
 
     if (group.getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       // If you're not admin of this group, you have to be super user
       userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
     }
@@ -133,7 +133,7 @@ public class UserGroupMemberEndpoint {
                         HttpStatus.BAD_REQUEST, "Group membership not found"));
 
     if (userGroupMember.getGroup().getAdmins().stream()
-        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equals(userEmail))) {
+        .noneMatch(groupAdmin -> groupAdmin.getUser().getEmail().equalsIgnoreCase(userEmail))) {
       // If you're not admin of this group, you have to be super user
       userIdentity.checkGlobalUserPermission(userEmail, UserGroupAuthorisedActivityType.SUPER_USER);
     }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupAdminRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserGroupAdminRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.UserGroupAdmin;
 
 public interface UserGroupAdminRepository extends JpaRepository<UserGroupAdmin, UUID> {
-  List<UserGroupAdmin> findByUserEmail(String email);
+  List<UserGroupAdmin> findByUserEmailIgnoreCase(String email);
 
   List<UserGroupAdmin> findByGroupId(UUID groupId);
 
-  boolean existsByUserEmail(String email);
+  boolean existsByUserEmailIgnoreCase(String userEmail);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.User;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-  Optional<User> findByEmail(String email);
+  Optional<User> findByEmailIgnoreCase(String email);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -55,7 +55,7 @@ public class UserIdentity {
       return;
     }
 
-    Optional<User> userOpt = userRepository.findByEmail(userEmail);
+    Optional<User> userOpt = userRepository.findByEmailIgnoreCase(userEmail);
 
     if (!userOpt.isPresent()) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User not known to RM");
@@ -96,7 +96,7 @@ public class UserIdentity {
       return;
     }
 
-    Optional<User> userOpt = userRepository.findByEmail(userEmail);
+    Optional<User> userOpt = userRepository.findByEmailIgnoreCase(userEmail);
 
     if (!userOpt.isPresent()) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User not known to RM");

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/UserIdentity.java
@@ -49,7 +49,7 @@ public class UserIdentity {
 
   public void checkUserPermission(
       String userEmail, Survey survey, UserGroupAuthorisedActivityType activity) {
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return;
@@ -90,7 +90,7 @@ public class UserIdentity {
   public void checkGlobalUserPermission(
       String userEmail, UserGroupAuthorisedActivityType activity) {
 
-    if (dummyUserIdentityAllowed && userEmail.equals(dummySuperUserIdentity)) {
+    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
       // Dummy test super user is fully authorised, bypassing all security
       // This is **STRICTLY** for ease of dev/testing in non-production environments
       return;

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -130,7 +130,11 @@ class UserAdmin extends Component {
 
     this.createUserInProgress = true;
 
-    if (this.state.users.map((user) => user.email.toLowerCase()).includes(this.state.email.toLowerCase())) {
+    if (
+      this.state.users
+        .map((user) => user.email.toLowerCase())
+        .includes(this.state.email.toLowerCase())
+    ) {
       this.setState({
         emailValidationError: "User already exists",
       });

--- a/ui/src/UserAdmin.js
+++ b/ui/src/UserAdmin.js
@@ -130,7 +130,7 @@ class UserAdmin extends Component {
 
     this.createUserInProgress = true;
 
-    if (this.state.users.map((user) => user.email).includes(this.state.email)) {
+    if (this.state.users.map((user) => user.email.toLowerCase()).includes(this.state.email.toLowerCase())) {
       this.setState({
         emailValidationError: "User already exists",
       });


### PR DESCRIPTION
# Motivation and Context
Could add same email twice, and lookup on email could fail if case different

# What has changed
Made case insensitive lookups

# How to test?
Can you add the same email twice, but with a different case letter? hopefully not.  

# Links
https://trello.com/c/IQ5b0zYl/3309-defect-adding-user-emails-in-support-tool-is-case-sensitive-5
