### PR TITLE
Removed dockerfile plugin from pom file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,7 @@ rm -r ui/build/* || true
 
 if [ "$SKIP_TESTS" = true ] ; then
   mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true
-  docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 else
   mvn clean install
-  docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 fi
+docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,8 @@ rm -r ui/build/* || true
 
 if [ "$SKIP_TESTS" = true ] ; then
   mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true
+  docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 else
   mvn clean install
+  docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -255,25 +255,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>dockerfile-maven-plugin</artifactId>
-        <version>1.4.10</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <repository>europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/${project.artifactId}</repository>
-              <buildArgs>
-                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-              </buildArgs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.13</version>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The spotify dockerfile plugin has become out of date we've decided to remove it and use just a normal docker build after a mvn clean install

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed spotify dockerfile plugin
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` and you should see it run mvn clean install and create a docker image with the jar afterwards
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/AHXXdTc5/)

