### PR TITLE
40 migrate java base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM europe-west2-docker.pkg.dev/ssdc-rm-liamtoozer-349808/docker/jdk17-mvn-node16-npm:latest
 CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
 
 RUN groupadd --gid 999 supporttool && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM europe-west2-docker.pkg.dev/ssdc-rm-liamtoozer-349808/docker/jdk17-mvn-node16-npm:latest
-CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
+FROM eclipse-temurin:17-jdk-alpine
 
-RUN groupadd --gid 999 supporttool && \
-    useradd --create-home --system --uid 999 --gid supporttool supporttool
+CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
 
-RUN apt-get update && \
-apt-get -yq install curl && \
-apt-get -yq clean && \
-rm -rf /var/lib/apt/lists/*
-
+RUN addgroup --gid 1000 supporttool && \
+    adduser --system --uid 1000 supporttool supporttool
 USER supporttool
 
 ARG JAR_FILE=ssdc-rm-support-tool*.jar
+
 COPY target/$JAR_FILE /opt/ssdc-rm-support-tool.jar


### PR DESCRIPTION
# Motivation and Context
OpenJDK support not great, use this eclipse alpine instead

# What has changed
Base image and healthchecks, user etc

# How to test?
Should all work with ATs etc with zero regression

# Links
https://trello.com/c/EK2yClBJ/40-migrate-java-base-docker-image-5
