### PR TITLE
Malformed files should error with file not valid

### DIFF
--- a/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkStagerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkStagerTest.java
@@ -1,0 +1,104 @@
+package uk.gov.ons.ssdc.supporttool.schedule;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.opencsv.CSVReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.ssdc.common.model.entity.*;
+import uk.gov.ons.ssdc.supporttool.model.repository.JobRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.JobRowRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class RowChunkStagerTest {
+  @Mock private JobRepository jobRepository;
+
+  @Mock private JobRowRepository jobRowRepository;
+
+  @Captor private ArgumentCaptor<List<JobRow>> jobRowCaptor;
+
+  @Captor private ArgumentCaptor<Job> jobCaptor;
+
+  @Mock CSVReader csvReader;
+
+  @InjectMocks RowChunkStager underTest;
+
+  @Test
+  void testRowChunkStagerFailedWithNullChunk() throws IOException {
+    Job job = getJob();
+
+    String[] headerRow = {"a", "b", "c"};
+
+    when(csvReader.readNext()).thenReturn(null);
+
+    JobStatus jobStatus = underTest.stageChunk(job, headerRow, csvReader);
+
+    assertThat(jobStatus).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    verify(csvReader).readNext();
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getFatalErrorDescription())
+        .isEqualTo(
+            "Failed to process job due to an empty chunk, this probably indicates a mismatch between file line count and row count");
+  }
+
+  @Test
+  void testRowChunkStagerSuccess() throws IOException {
+    Job job = getJob();
+
+    String[] headerRow = {"a", "b", "c"};
+
+    when(csvReader.readNext()).thenReturn(new String[] {"1", "2", "3"}).thenReturn(null);
+
+    JobStatus jobStatus = underTest.stageChunk(job, headerRow, csvReader);
+
+    assertThat(jobStatus).isEqualTo(JobStatus.VALIDATION_IN_PROGRESS);
+    verify(csvReader, times(2)).readNext();
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getStagingRowNumber()).isEqualTo(1);
+
+    verify(jobRowRepository).saveAll(jobRowCaptor.capture());
+    List<JobRow> jobRow = jobRowCaptor.getValue();
+
+    assertThat(jobRow.get(0).getJob()).isEqualTo(capturedJob);
+    assertThat(jobRow.get(0).getRowData()).isEqualTo(Map.of("a", "1", "b", "2", "c", "3"));
+  }
+
+  @Test
+  void testRowChunkStagerFailedWithIOException() throws IOException {
+    Job job = getJob();
+
+    String[] headerRow = {"a", "b", "c"};
+
+    when(csvReader.readNext()).thenThrow(new IOException());
+
+    JobStatus jobStatus = underTest.stageChunk(job, headerRow, csvReader);
+
+    assertThat(jobStatus).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    verify(csvReader).readNext();
+  }
+
+  private Job getJob() {
+    CollectionExercise collectionExercise = new CollectionExercise();
+    Job job = new Job();
+    job.setCollectionExercise(collectionExercise);
+    job.setJobStatus(JobStatus.FILE_UPLOADED);
+    job.setJobType(JobType.SAMPLE);
+    job.setFileRowCount(1);
+    job.setId(UUID.randomUUID());
+    job.setFileId(UUID.randomUUID());
+    return job;
+  }
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Yogi found a bug in support tool where a sample file for email addresses errors gets stuck in a staging loop and the only way to fix it is through manually changing it in the DB. This is an attempt to fix the error. From what I could see from Yogis example, the file took two lines as one line job row and then got stuck in a while loop. I've tried to fix this by checking whether the line is null and it's the first iteration. This should mean that the file is at the end of the file and shouldn't be possible to have a null so we exit with a file not valid error.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added a check to exit out of the staging loop
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the sample file attached to the ticket and it shouldn't get stuck processing the file
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/OoSEAOeK/)

