### PR TITLE
add setCollectionInstrumentSelectionRules to exports Collex

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/CollectionExerciseEndpoint.java
@@ -179,6 +179,8 @@ public class CollectionExerciseEndpoint {
     collectionExerciseUpdate.setStartDate(collectionExercise.getStartDate());
     collectionExerciseUpdate.setEndDate(collectionExercise.getEndDate());
     collectionExerciseUpdate.setMetadata(collectionExercise.getMetadata());
+    collectionExerciseUpdate.setCollectionInstrumentSelectionRules(
+            collectionExerciseDto.getCollectionInstrumentSelectionRules());
 
     PayloadDTO payloadDTO = new PayloadDTO();
     payloadDTO.setCollectionExerciseUpdate(collectionExerciseUpdate);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/CollectionExerciseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/messaging/CollectionExerciseUpdateDTO.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ssdc.supporttool.model.dto.messaging;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Data;
+import uk.gov.ons.ssdc.common.model.entity.CollectionInstrumentSelectionRule;
 
 @Data
 public class CollectionExerciseUpdateDTO {
@@ -13,4 +14,5 @@ public class CollectionExerciseUpdateDTO {
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
   private Object metadata;
+  private CollectionInstrumentSelectionRule[] collectionInstrumentSelectionRules;
 }


### PR DESCRIPTION
# Motivation and Context
Collection Exercise Rules required in RH Service in order to get EQ Schema, for token

# What has changed
Very simple change to CollectionExcerciseDTO Model and population

# How to test?
This is just a spike at the moment, does RH-service process it?

# Links
https://trello.com/c/GAI7oS90/227-spike-eq-claim-token-1-day