### PR TITLE
Stop logging exception directly,  instead save message against Job

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
@@ -93,7 +93,7 @@ public class FileStager {
             jobStatus = JobStatus.VALIDATED_TOTAL_FAILURE;
             job.setFatalErrorDescription(
                 "Header row does not match expected columns, received: ["
-                    + headerRow[index].substring(0, 150)
+                    + headerRow[index]
                     + "] expected: ["
                     + expectedColumns[index]
                     + "]");

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/FileStager.java
@@ -93,7 +93,7 @@ public class FileStager {
             jobStatus = JobStatus.VALIDATED_TOTAL_FAILURE;
             job.setFatalErrorDescription(
                 "Header row does not match expected columns, received: ["
-                    + headerRow[index]
+                    + headerRow[index].substring(0, 150)
                     + "] expected: ["
                     + expectedColumns[index]
                     + "]");
@@ -115,7 +115,14 @@ public class FileStager {
 
       return jobStatus;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      log.with("file_id", job.getFileId())
+          .with("job_id", job.getId())
+          .with("file_name", job.getFileName())
+          .error("IOException checking header row, CSV data is malformed");
+
+      job.setFatalErrorDescription("Exception Message: " + e.getMessage());
+      job.setJobStatus(JobStatus.VALIDATED_TOTAL_FAILURE);
+      return JobStatus.VALIDATED_TOTAL_FAILURE;
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowChunkStager.java
@@ -83,8 +83,11 @@ public class RowChunkStager {
           .with("file_id", job.getFileId())
           .with("job_id", job.getId())
           .with("file_name", job.getFileName())
-          .with("exceptionMessage", e.getMessage())
-          .error(e, "IOException staging job row, CSV data is malformed");
+          .error("IOException staging job row, CSV data is malformed");
+
+      job.setFatalErrorDescription("Exception Message: " + e.getMessage());
+      jobRepository.saveAndFlush(job);
+
       return JobStatus.VALIDATED_TOTAL_FAILURE;
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -125,6 +125,7 @@ public class RowStager {
           .error("IOException staging job, CSV data is malformed");
 
       job.setFatalErrorDescription("Exception Message: " + e.getMessage());
+      job.setJobStatus(JobStatus.VALIDATED_TOTAL_FAILURE);
       jobRepository.saveAndFlush(job);
     }
   }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/schedule/RowStager.java
@@ -119,7 +119,13 @@ public class RowStager {
             });
       }
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      log.with("file_id", job.getFileId())
+          .with("job_id", job.getId())
+          .with("file_name", job.getFileName())
+          .error("IOException staging job, CSV data is malformed");
+
+      job.setFatalErrorDescription("Exception Message: " + e.getMessage());
+      jobRepository.saveAndFlush(job);
     }
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/FileStagerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/FileStagerTest.java
@@ -1,0 +1,171 @@
+package uk.gov.ons.ssdc.supporttool.schedule;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.io.*;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.common.model.entity.*;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.common.validation.MandatoryRule;
+import uk.gov.ons.ssdc.common.validation.Rule;
+import uk.gov.ons.ssdc.supporttool.model.repository.JobRepository;
+import uk.gov.ons.ssdc.supporttool.utility.JobTypeHelper;
+
+@ExtendWith(MockitoExtension.class)
+public class FileStagerTest {
+  @Mock private JobRepository jobRepository;
+
+  private final String fileUploadStoragePath = "/tmp/";
+
+  @Mock private JobTypeHelper jobTypeHelper;
+
+  @Captor private ArgumentCaptor<Job> jobCaptor;
+
+  @InjectMocks FileStager underTest;
+
+  @BeforeEach
+  public void setup() {
+    ReflectionTestUtils.setField(underTest, "fileUploadStoragePath", fileUploadStoragePath);
+  }
+
+  @Test
+  void testFileStagerSuccess() throws IOException {
+    // Given
+    Job job = getJob();
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "Junk");
+    when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
+    when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
+        .thenReturn(new String[] {"Junk"});
+
+    // When
+    underTest.processFiles();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.STAGING_IN_PROGRESS);
+  }
+
+  @Test
+  void testFileStagerUnexpectedColumnName() throws IOException {
+    // Given
+    Job job = getJob();
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "Junk");
+    when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
+    when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
+        .thenReturn(new String[] {"Funk"});
+
+    // When
+    underTest.processFiles();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+  }
+
+  @Test
+  void testFileStagerMismatchColumns() throws IOException {
+    // Given
+    Job job = getJob();
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "Junk");
+    when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
+    when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
+        .thenReturn(new String[] {"Junk", "Funk"});
+
+    // When
+    underTest.processFiles();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    assertThat(capturedJob.getFatalErrorDescription())
+        .isEqualTo("Header row does not have expected number of columns");
+  }
+
+  @Test
+  void testRowChunkStagerFailedWithIOException() throws IOException {
+    // Given
+    Job job = getJob();
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+
+    createFile(job, "\"junk");
+
+    when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
+
+    // When
+    underTest.processFiles();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    assertThat(capturedJob.getFatalErrorDescription()).contains("Exception Message");
+  }
+
+  @Test
+  void testFileStagerFileDoesNotExist() {
+    // Given
+    Job job = getJob();
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
+
+    // When
+    underTest.processFiles();
+
+    // // Then
+    assertThat(job.getJobStatus()).isEqualTo(JobStatus.FILE_UPLOADED);
+  }
+
+  private void createFile(Job job, String header) throws IOException {
+    File file = new File("/tmp/" + job.getFileId());
+    file.createNewFile();
+    file.deleteOnExit();
+    FileWriter fw = new FileWriter(file.getPath(), true);
+    BufferedWriter bw = new BufferedWriter(fw);
+    bw.write(header);
+    bw.newLine();
+    bw.write("Blah");
+    bw.close();
+  }
+
+  private Job getJob() {
+    CollectionExercise collectionExercise = new CollectionExercise();
+    Survey survey = new Survey();
+    survey.setName("test_survey-" + UUID.randomUUID());
+    survey.setSampleSeparator(',');
+    survey.setSampleValidationRules(
+        new ColumnValidator[] {
+          new ColumnValidator("Junk", false, new Rule[] {new MandatoryRule()})
+        });
+    survey.setSampleWithHeaderRow(true);
+    collectionExercise.setSurvey(survey);
+    Job job = new Job();
+    job.setCollectionExercise(collectionExercise);
+    job.setJobStatus(JobStatus.FILE_UPLOADED);
+    job.setJobType(JobType.SAMPLE);
+    job.setFileRowCount(1);
+    job.setId(UUID.randomUUID());
+    job.setFileId(UUID.randomUUID());
+    return job;
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/FileStagerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/FileStagerTest.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ssdc.supporttool.schedule;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.ssdc.supporttool.testhelper.ScheduleHelper.createFile;
 
 import java.io.*;
 import java.util.*;
@@ -43,7 +42,7 @@ public class FileStagerTest {
     Job job = ScheduleHelper.getJob("Junk", true, JobStatus.FILE_UPLOADED);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "Junk");
+    ScheduleHelper.createFile(job, "Junk");
     when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
     when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
         .thenReturn(new String[] {"Junk"});
@@ -63,7 +62,7 @@ public class FileStagerTest {
     Job job = ScheduleHelper.getJob("Junk", true, JobStatus.FILE_UPLOADED);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "Junk");
+    ScheduleHelper.createFile(job, "Junk");
     when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
     when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
         .thenReturn(new String[] {"Funk"});
@@ -83,7 +82,7 @@ public class FileStagerTest {
     Job job = ScheduleHelper.getJob("Junk", true, JobStatus.FILE_UPLOADED);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "Junk");
+    ScheduleHelper.createFile(job, "Junk");
     when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
     when(jobTypeHelper.getExpectedColumns(job.getJobType(), job.getCollectionExercise()))
         .thenReturn(new String[] {"Junk", "Funk"});
@@ -106,7 +105,7 @@ public class FileStagerTest {
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
 
-    createFile(job, "\"junk");
+    ScheduleHelper.createFile(job, "\"junk");
 
     when(jobRepository.findByJobStatus(JobStatus.FILE_UPLOADED)).thenReturn(jobList);
 
@@ -131,7 +130,7 @@ public class FileStagerTest {
     // When
     underTest.processFiles();
 
-    // // Then
+    // Then
     assertThat(job.getJobStatus()).isEqualTo(JobStatus.FILE_UPLOADED);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowStagerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowStagerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.ssdc.supporttool.testhelper.ScheduleHelper.createFile;
+import static uk.gov.ons.ssdc.supporttool.testhelper.ScheduleHelper.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public class RowStagerTest {
     job.setStagingRowNumber(1);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "Junk");
+    ScheduleHelper.createFile(job, "Junk");
     when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
     doAnswer(
             (i) -> {
@@ -76,7 +76,7 @@ public class RowStagerTest {
     Job job = ScheduleHelper.getJob("Junk", false, JobStatus.STAGING_IN_PROGRESS);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "Junk");
+    ScheduleHelper.createFile(job, "Junk");
     when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
     when(rowChunkStager.stageChunk(eq(job), any(), any()))
         .thenReturn(JobStatus.VALIDATED_TOTAL_FAILURE);
@@ -97,7 +97,7 @@ public class RowStagerTest {
     Job job = ScheduleHelper.getJob("Junk", true, JobStatus.STAGING_IN_PROGRESS);
     List<Job> jobList = new ArrayList<>();
     jobList.add(job);
-    createFile(job, "\"Junk");
+    ScheduleHelper.createFile(job, "\"Junk");
     when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
 
     // When
@@ -121,7 +121,7 @@ public class RowStagerTest {
     // When
     underTest.processRows();
 
-    // // Then
+    // Then
     assertThat(job.getJobStatus()).isEqualTo(JobStatus.STAGING_IN_PROGRESS);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowStagerTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/schedule/RowStagerTest.java
@@ -1,0 +1,127 @@
+package uk.gov.ons.ssdc.supporttool.schedule;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.gov.ons.ssdc.supporttool.testhelper.ScheduleHelper.createFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ssdc.common.model.entity.*;
+import uk.gov.ons.ssdc.supporttool.model.repository.JobRepository;
+import uk.gov.ons.ssdc.supporttool.model.repository.JobRowRepository;
+import uk.gov.ons.ssdc.supporttool.testhelper.ScheduleHelper;
+import uk.gov.ons.ssdc.supporttool.utility.JobTypeHelper;
+
+@ExtendWith(MockitoExtension.class)
+public class RowStagerTest {
+  @Mock private JobRepository jobRepository;
+  @Mock private JobRowRepository jobRowRepository;
+  @Mock private JobTypeHelper jobTypeHelper;
+
+  private final String fileUploadStoragePath = "/tmp/";
+
+  @Mock private RowChunkStager rowChunkStager;
+
+  @Captor private ArgumentCaptor<Job> jobCaptor;
+
+  @InjectMocks RowStager underTest;
+
+  @BeforeEach
+  public void setup() {
+    ReflectionTestUtils.setField(underTest, "fileUploadStoragePath", fileUploadStoragePath);
+  }
+
+  @Test
+  void testRowStagerSuccess() throws IOException {
+    // Given
+    Job job = ScheduleHelper.getJob("Junk", true, JobStatus.STAGING_IN_PROGRESS);
+    job.setStagingRowNumber(1);
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "Junk");
+    when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
+    doAnswer(
+            (i) -> {
+              job.setStagingRowNumber(job.getStagingRowNumber() + 1);
+              return JobStatus.VALIDATION_IN_PROGRESS;
+            })
+        .when(rowChunkStager)
+        .stageChunk(eq(job), any(), any());
+
+    // When
+    underTest.processRows();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATION_IN_PROGRESS);
+    assertThat(capturedJob.getStagingRowNumber()).isEqualTo(2);
+  }
+
+  @Test
+  void testRowStagerFailedToStageChunk() throws IOException {
+    // Given
+    Job job = ScheduleHelper.getJob("Junk", false, JobStatus.STAGING_IN_PROGRESS);
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "Junk");
+    when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
+    when(rowChunkStager.stageChunk(eq(job), any(), any()))
+        .thenReturn(JobStatus.VALIDATED_TOTAL_FAILURE);
+
+    // When
+    underTest.processRows();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    verify(jobRowRepository).deleteByJob(any());
+  }
+
+  @Test
+  void testRowStagerThrowIOException() throws IOException {
+    // Given
+    Job job = ScheduleHelper.getJob("Junk", true, JobStatus.STAGING_IN_PROGRESS);
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    createFile(job, "\"Junk");
+    when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
+
+    // When
+    underTest.processRows();
+
+    // Then
+    verify(jobRepository).saveAndFlush(jobCaptor.capture());
+    Job capturedJob = jobCaptor.getValue();
+    assertThat(capturedJob.getJobStatus()).isEqualTo(JobStatus.VALIDATED_TOTAL_FAILURE);
+    assertThat(capturedJob.getFatalErrorDescription()).contains("Exception Message");
+  }
+
+  @Test
+  void testFileStagerFileDoesNotExist() {
+    // Given
+    Job job = ScheduleHelper.getJob("Junk", true, JobStatus.STAGING_IN_PROGRESS);
+    List<Job> jobList = new ArrayList<>();
+    jobList.add(job);
+    when(jobRepository.findByJobStatus(JobStatus.STAGING_IN_PROGRESS)).thenReturn(jobList);
+
+    // When
+    underTest.processRows();
+
+    // // Then
+    assertThat(job.getJobStatus()).isEqualTo(JobStatus.STAGING_IN_PROGRESS);
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/ScheduleHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/ScheduleHelper.java
@@ -1,0 +1,48 @@
+package uk.gov.ons.ssdc.supporttool.testhelper;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+import uk.gov.ons.ssdc.common.model.entity.*;
+import uk.gov.ons.ssdc.common.validation.ColumnValidator;
+import uk.gov.ons.ssdc.common.validation.MandatoryRule;
+import uk.gov.ons.ssdc.common.validation.Rule;
+
+public class ScheduleHelper {
+  public static Job getJob(String columnName, boolean sampleWithHeaderRow, JobStatus jobStatus) {
+    CollectionExercise collectionExercise = new CollectionExercise();
+    Survey survey = new Survey();
+    survey.setName("test_survey-" + UUID.randomUUID());
+    survey.setSampleSeparator(',');
+    survey.setSampleValidationRules(
+        new ColumnValidator[] {
+          new ColumnValidator(columnName, false, new Rule[] {new MandatoryRule()})
+        });
+    survey.setSampleWithHeaderRow(sampleWithHeaderRow);
+    collectionExercise.setSurvey(survey);
+    Job job = new Job();
+    job.setCollectionExercise(collectionExercise);
+    job.setJobStatus(jobStatus);
+    job.setJobType(JobType.SAMPLE);
+    job.setFileRowCount(3);
+    job.setId(UUID.randomUUID());
+    job.setFileId(UUID.randomUUID());
+    return job;
+  }
+
+  public static void createFile(Job job, String header) throws IOException {
+    File file = new File("/tmp/" + job.getFileId());
+    file.createNewFile();
+    file.deleteOnExit();
+    FileWriter fw = new FileWriter(file.getPath(), true);
+    BufferedWriter bw = new BufferedWriter(fw);
+    bw.write(header);
+    bw.newLine();
+    bw.write("Blah");
+    bw.newLine();
+    bw.write("Blah2");
+    bw.close();
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Previously logged out exception message with sensitive data from file

# What has changed
Stops doing this, instead stores it against the job.  This is valid as data is already stored against the job, so the sensitive data is allowed to exist in that environment.

# How to test?
File attached to Ticket.  Build this branch.  make up in docker dev.   
Run "A simple email sample driven survey can be run in SRM" from ATs to get rules etc set up.
Then in your support tool locally http://localhost:9999/ navigate to the survey and collex.  
Then upload the 'bad_email_file.csv' from the ticket

# Links
https://trello.com/c/NgMahPqN/238-java-opencsv-puts-csv-data-in-exception-messages-1-day
