### PR TITLE
256 Add explicit CDN for manifest link

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/WebSecurityConfig.java
@@ -27,7 +27,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)
         .and()
         .contentSecurityPolicy(
-            String.format("default-src 'self'; manifest-src %s ; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content", TRUSTED_CDN_DOMAIN))
+            String.format(
+                "default-src 'self'; manifest-src %s ; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content",
+                TRUSTED_CDN_DOMAIN))
         .and()
         .permissionsPolicy()
         .policy(

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/config/WebSecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
+  private static final String TRUSTED_CDN_DOMAIN = "https://cdn.ons.gov.uk/";
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.headers()
@@ -25,7 +27,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)
         .and()
         .contentSecurityPolicy(
-            "default-src 'self'; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content")
+            String.format("default-src 'self'; manifest-src %s ; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content", TRUSTED_CDN_DOMAIN))
         .and()
         .permissionsPolicy()
         .policy(

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -104,7 +104,7 @@ public class IntegrationTestHelper {
     assertThat(response.getHeaders().get("Referrer-Policy").get(0)).isEqualTo("no-referrer");
     assertThat(response.getHeaders().get("Content-Security-Policy").get(0))
         .isEqualTo(
-            "default-src 'self'; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content");
+            "default-src 'self'; manifest-src https://cdn.ons.gov.uk/ ; style-src 'self' 'unsafe-inline' ; upgrade-insecure-requests; block-all-mixed-content");
     assertThat(response.getHeaders().get("Strict-Transport-Security").get(0))
         .isEqualTo("max-age=31536000 ; includeSubDomains");
     assertThat(response.getHeaders().get("X-Frame-Options").get(0)).isEqualTo("DENY");

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -14,7 +14,10 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="https://cdn.ons.gov.uk/sdc/design-system/44.1.2/favicons/manifest.json" />
+    <link
+      rel="manifest"
+      href="https://cdn.ons.gov.uk/sdc/design-system/44.1.2/favicons/manifest.json"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -14,7 +14,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="https://cdn.ons.gov.uk/sdc/design-system/44.1.2/favicons/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We were getting chrome errors around the manifest used for static asset lookups. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Explicitly set the CDN manifest (same  as the ROps)
* Add trusted domain to `manifest-src` in CSP header

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run this in your GCP. Ensure the same error doesn't pop up when you inspect the console in your browser.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/tWLjQVOG
