### PR TITLE
works with the supportTookFakeIAP.py proxy runing on 8080

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/AuthorisationEndpoint.java
@@ -29,32 +29,15 @@ public class AuthorisationEndpoint {
   private static final Logger log = LoggerFactory.getLogger(AuthorisationEndpoint.class);
 
   private final UserRepository userRepository;
-  private final boolean dummyUserIdentityAllowed;
-  private final String dummySuperUserIdentity;
 
-  public AuthorisationEndpoint(
-      UserRepository userRepository,
-      @Value("${dummyuseridentity-allowed}") boolean dummyUserIdentityAllowed,
-      @Value("${dummysuperuseridentity}") String dummySuperUserIdentity) {
+  public AuthorisationEndpoint(UserRepository userRepository) {
     this.userRepository = userRepository;
-    this.dummyUserIdentityAllowed = dummyUserIdentityAllowed;
-    this.dummySuperUserIdentity = dummySuperUserIdentity;
-
-    if (dummyUserIdentityAllowed) {
-      log.error("*** SECURITY ALERT *** IF YOU SEE THIS IN PRODUCTION, SHUT DOWN IMMEDIATELY!!!");
-    }
   }
 
   @GetMapping
   public Set<UserGroupAuthorisedActivityType> getAuthorisedActivities(
       @RequestParam(required = false, value = "surveyId") Optional<UUID> surveyId,
       @Value("#{request.getAttribute('userEmail')}") String userEmail) {
-
-    if (dummyUserIdentityAllowed && userEmail.equalsIgnoreCase(dummySuperUserIdentity)) {
-      // Dummy test super user is fully authorised, bypassing all security
-      // This is **STRICTLY** for ease of dev/testing in non-production environments
-      return Set.of(UserGroupAuthorisedActivityType.values());
-    }
 
     Optional<User> userOpt = userRepository.findByEmailIgnoreCase(userEmail);
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,4 +8,4 @@ spring:
 queueconfig:
   shared-pubsub-project: shared-project
 
-dummyuseridentity-allowed: true # This ** MUST ALWAYS!! ** be false in production!!!
+iapaudience: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,11 +75,8 @@ notifyservice:
     host: localhost
     port: 8162
 
-iapaudience: DUMMY
-
-dummyuseridentity-allowed: false # This ** MUST ALWAYS!! ** be false in production!!!
-dummyuseridentity: dummy@fake-email.com
-dummysuperuseridentity: dummy@fake-email.com
+# false FOR TESTING ONLY, REMOVE ENTIRELY WHENN COMMITTING
+iapaudience: false
 
 exportfiledestinationconfigfile: dummy-export-file-destination-config.json
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,5 +18,4 @@ exception-manager:
 queueconfig:
   shared-pubsub-project: shared-project
 
-dummyuseridentity-allowed: true # This ** MUST ALWAYS!! ** be false in production!!!
-dummyuseridentity: integration-tests@testymctest.com
+iapaudience: false

--- a/supportToolFakeIAP.py
+++ b/supportToolFakeIAP.py
@@ -1,0 +1,43 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import time
+import requests
+
+hostName = "localhost"
+serverPort = 8080
+
+super_user = "bob@bob.com"
+
+
+class MyServer(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+
+        response = requests.get("http://127.0.0.1:9999" + self.path,
+                                headers={"x-goog-iap-jwt-assertion": super_user})
+
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(bytes(response.text, encoding='utf8'))
+
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(bytes("<html><head><title>https://pythonbasics.org</title></head>", "utf-8"))
+        self.wfile.write(bytes("<p>Request: %s</p>" % self.path, "utf-8"))
+        self.wfile.write(bytes("<body>", "utf-8"))
+        self.wfile.write(bytes("<p>NOT IMPLEMENTED.</p>", "utf-8"))
+        self.wfile.write(bytes("</body></html>", "utf-8"))
+
+
+if __name__ == "__main__":
+    webServer = HTTPServer((hostName, serverPort), MyServer)
+    print("Server started http://%s:%s" % (hostName, serverPort))
+
+    try:
+        webServer.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    webServer.server_close()
+    print("Server stopped.")

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "ssdc-rm-support-tool",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:9999",
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "@fontsource/roboto": "^4.2.3",
     "@material-ui/core": "^4.11.4",


### PR DESCRIPTION
This relies locally on a proxy adding an email address rather than IAP adding a whole JWT. It's less production code.  It sorta works alright, but is more fiddly. Feels safer, just 1 switch.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
