### PR TITLE
457 warn if file over 100mb

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
   servlet:
     multipart:
       enabled: true
+#     If these values change then you must update the max_file_size_in_mb in SampleUpload.js
       max-file-size: 100MB
       max-request-size: 100MB
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 500MB
-      max-request-size: 500MB
+      max-file-size: 100MB
+      max-request-size: 100MB
 
   datasource:
     url: jdbc:postgresql://localhost:6432/postgres?readOnly=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 100MB
-      max-request-size: 100MB
+      max-file-size: 500MB
+      max-request-size: 500MB
 
   datasource:
     url: jdbc:postgresql://localhost:6432/postgres?readOnly=true

--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -142,9 +142,9 @@ class BulkUploads extends Component {
       alert(
         "Maximum file size is " +
           max_file_size_in_mb +
-          " This file size is: " +
+          "MB. This file size is: " +
           file_size_in_mb +
-          " MB"
+          "MB."
       );
       return;
     }

--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -249,8 +249,8 @@ class BulkUploads extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-                <CircularProgress size={15} style={{ marginLeft: 10 }} />
-              )}
+              <CircularProgress size={15} style={{ marginLeft: 10 }} />
+            )}
           </Button>
         </TableCell>
       </TableRow>

--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -249,8 +249,8 @@ class BulkUploads extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-              <CircularProgress size={15} style={{ marginLeft: 10 }} />
-            )}
+                <CircularProgress size={15} style={{ marginLeft: 10 }} />
+              )}
           </Button>
         </TableCell>
       </TableRow>
@@ -386,7 +386,7 @@ class BulkUploads extends Component {
         <Dialog open={this.state.uploadInProgress}>
           <DialogContent style={{ padding: 30 }}>
             <Typography variant="h6" color="inherit">
-              Uploading file...
+              Uploading file. Do not close or refresh this tab.
             </Typography>
             <LinearProgress
               variant="determinate"

--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -140,9 +140,11 @@ class BulkUploads extends Component {
 
     if (file_size_in_mb > max_file_size_in_mb) {
       alert(
-        "Maximum file size is 100mb.  This file size is: " +
+        "Maximum file size is " +
+          max_file_size_in_mb +
+          " This file size is: " +
           file_size_in_mb +
-          " mb"
+          " MB"
       );
       return;
     }

--- a/ui/src/BulkUploads.js
+++ b/ui/src/BulkUploads.js
@@ -131,6 +131,22 @@ class BulkUploads extends Component {
       return;
     }
 
+    // This must be <= spring.servlet.multipart.max-file-size: x
+    const max_file_size_in_mb = 100;
+
+    // Comment here to explain why 1,000,000 and not 1024*1024.
+    // Only dividing by 1,000,000 gives the size in mb that agrees with value on mac
+    var file_size_in_mb = event.target.files[0].size / 1000000;
+
+    if (file_size_in_mb > max_file_size_in_mb) {
+      alert(
+        "Maximum file size is 100mb.  This file size is: " +
+          file_size_in_mb +
+          " mb"
+      );
+      return;
+    }
+
     // Display the progress modal dialog
     this.setState({
       uploadInProgress: true,

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -47,6 +47,19 @@ class SampleUpload extends Component {
       return;
     }
 
+    // Comment here to explain why 1,000,000 and not 1024*1024.
+    // Only dividing by 1,000,000 gives the size in mb that agrees with value on mac
+    var file_size_in_mb = e.target.files[0].size / 1000000;
+
+    if (file_size_in_mb > 500) {
+      alert(
+        "Maimum file size is 500mb.  This file size is: " +
+          file_size_in_mb +
+          " mb"
+      );
+      return;
+    }
+
     // Display the progress modal dialog
     this.setState({
       uploadInProgress: true,

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -51,11 +51,11 @@ class SampleUpload extends Component {
     // Only dividing by 1,000,000 gives the size in mb that agrees with value on mac
     var file_size_in_mb = e.target.files[0].size / 1000000;
 
-    if (file_size_in_mb > 500) {
+    if (file_size_in_mb > 100) {
       alert(
-        "Maimum file size is 500mb.  This file size is: " +
-          file_size_in_mb +
-          " mb"
+        "Maimum file size is 100mb.  This file size is: " +
+        file_size_in_mb +
+        " mb"
       );
       return;
     }
@@ -119,6 +119,8 @@ class SampleUpload extends Component {
 
         this.getJobs();
       });
+    // handle some sort of 502 or other errors - let UI know 
+
   };
 
   handleClose = (event, reason) => {
@@ -191,8 +193,8 @@ class SampleUpload extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-              <CircularProgress size={15} style={{ marginLeft: 10 }} />
-            )}
+                <CircularProgress size={15} style={{ marginLeft: 10 }} />
+              )}
           </Button>
         </TableCell>
       </TableRow>
@@ -203,24 +205,24 @@ class SampleUpload extends Component {
         {this.props.authorisedActivities.includes(
           "VIEW_SAMPLE_LOAD_PROGRESS"
         ) && (
-          <>
-            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-              Uploaded Sample Files
-            </Typography>
-            <TableContainer component={Paper}>
-              <Table id="sampleFilesList">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>File Name</TableCell>
-                    <TableCell>Date Uploaded</TableCell>
-                    <TableCell align="right">Status</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>{jobTableRows}</TableBody>
-              </Table>
-            </TableContainer>
-          </>
-        )}
+            <>
+              <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+                Uploaded Sample Files
+              </Typography>
+              <TableContainer component={Paper}>
+                <Table id="sampleFilesList">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>File Name</TableCell>
+                      <TableCell>Date Uploaded</TableCell>
+                      <TableCell align="right">Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>{jobTableRows}</TableBody>
+                </Table>
+              </TableContainer>
+            </>
+          )}
         {this.props.authorisedActivities.includes("LOAD_SAMPLE") && (
           <>
             <input
@@ -247,7 +249,7 @@ class SampleUpload extends Component {
         <Dialog open={this.state.uploadInProgress}>
           <DialogContent style={{ padding: 30 }}>
             <Typography variant="h6" color="inherit">
-              Uploading file...
+              Uploading file. Do not close or refresh this tab.
             </Typography>
             <LinearProgress
               variant="determinate"

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -56,9 +56,11 @@ class SampleUpload extends Component {
 
     if (file_size_in_mb > max_file_size_in_mb) {
       alert(
-        "Maximum file size is 100mb.  This file size is: " +
+        "Maximum file size is " +
+          max_file_size_in_mb +
+          " This file size is: " +
           file_size_in_mb +
-          " mb"
+          " MB"
       );
       return;
     }

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -58,7 +58,7 @@ class SampleUpload extends Component {
       alert(
         "Maximum file size is " +
           max_file_size_in_mb +
-          " This file size is: " +
+          "MB. This file size is: " +
           file_size_in_mb +
           " MB"
       );

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -47,15 +47,18 @@ class SampleUpload extends Component {
       return;
     }
 
+    // This must be <= spring.servlet.multipart.max-file-size: x
+    const max_file_size_in_mb = 100;
+
     // Comment here to explain why 1,000,000 and not 1024*1024.
     // Only dividing by 1,000,000 gives the size in mb that agrees with value on mac
     var file_size_in_mb = e.target.files[0].size / 1000000;
 
-    if (file_size_in_mb > 100) {
+    if (file_size_in_mb > max_file_size_in_mb) {
       alert(
         "Maximum file size is 100mb.  This file size is: " +
-          file_size_in_mb +
-          " mb"
+        file_size_in_mb +
+        " mb"
       );
       return;
     }
@@ -191,8 +194,8 @@ class SampleUpload extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-              <CircularProgress size={15} style={{ marginLeft: 10 }} />
-            )}
+                <CircularProgress size={15} style={{ marginLeft: 10 }} />
+              )}
           </Button>
         </TableCell>
       </TableRow>
@@ -203,24 +206,24 @@ class SampleUpload extends Component {
         {this.props.authorisedActivities.includes(
           "VIEW_SAMPLE_LOAD_PROGRESS"
         ) && (
-          <>
-            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-              Uploaded Sample Files
-            </Typography>
-            <TableContainer component={Paper}>
-              <Table id="sampleFilesList">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>File Name</TableCell>
-                    <TableCell>Date Uploaded</TableCell>
-                    <TableCell align="right">Status</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>{jobTableRows}</TableBody>
-              </Table>
-            </TableContainer>
-          </>
-        )}
+            <>
+              <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+                Uploaded Sample Files
+              </Typography>
+              <TableContainer component={Paper}>
+                <Table id="sampleFilesList">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>File Name</TableCell>
+                      <TableCell>Date Uploaded</TableCell>
+                      <TableCell align="right">Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>{jobTableRows}</TableBody>
+                </Table>
+              </TableContainer>
+            </>
+          )}
         {this.props.authorisedActivities.includes("LOAD_SAMPLE") && (
           <>
             <input

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -57,8 +57,8 @@ class SampleUpload extends Component {
     if (file_size_in_mb > max_file_size_in_mb) {
       alert(
         "Maximum file size is 100mb.  This file size is: " +
-        file_size_in_mb +
-        " mb"
+          file_size_in_mb +
+          " mb"
       );
       return;
     }
@@ -194,8 +194,8 @@ class SampleUpload extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-                <CircularProgress size={15} style={{ marginLeft: 10 }} />
-              )}
+              <CircularProgress size={15} style={{ marginLeft: 10 }} />
+            )}
           </Button>
         </TableCell>
       </TableRow>
@@ -206,24 +206,24 @@ class SampleUpload extends Component {
         {this.props.authorisedActivities.includes(
           "VIEW_SAMPLE_LOAD_PROGRESS"
         ) && (
-            <>
-              <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-                Uploaded Sample Files
-              </Typography>
-              <TableContainer component={Paper}>
-                <Table id="sampleFilesList">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>File Name</TableCell>
-                      <TableCell>Date Uploaded</TableCell>
-                      <TableCell align="right">Status</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>{jobTableRows}</TableBody>
-                </Table>
-              </TableContainer>
-            </>
-          )}
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Uploaded Sample Files
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table id="sampleFilesList">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>File Name</TableCell>
+                    <TableCell>Date Uploaded</TableCell>
+                    <TableCell align="right">Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{jobTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {this.props.authorisedActivities.includes("LOAD_SAMPLE") && (
           <>
             <input

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -119,7 +119,6 @@ class SampleUpload extends Component {
 
         this.getJobs();
       });
-    // handle some sort of 502 or other errors - let UI know
   };
 
   handleClose = (event, reason) => {

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -53,7 +53,7 @@ class SampleUpload extends Component {
 
     if (file_size_in_mb > 100) {
       alert(
-        "Maimum file size is 100mb.  This file size is: " +
+        "Maximum file size is 100mb.  This file size is: " +
           file_size_in_mb +
           " mb"
       );

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -54,8 +54,8 @@ class SampleUpload extends Component {
     if (file_size_in_mb > 100) {
       alert(
         "Maimum file size is 100mb.  This file size is: " +
-        file_size_in_mb +
-        " mb"
+          file_size_in_mb +
+          " mb"
       );
       return;
     }
@@ -119,8 +119,7 @@ class SampleUpload extends Component {
 
         this.getJobs();
       });
-    // handle some sort of 502 or other errors - let UI know 
-
+    // handle some sort of 502 or other errors - let UI know
   };
 
   handleClose = (event, reason) => {
@@ -193,8 +192,8 @@ class SampleUpload extends Component {
               "VALIDATION_IN_PROGRESS",
               "PROCESSING_IN_PROGRESS",
             ].includes(job.jobStatus) && (
-                <CircularProgress size={15} style={{ marginLeft: 10 }} />
-              )}
+              <CircularProgress size={15} style={{ marginLeft: 10 }} />
+            )}
           </Button>
         </TableCell>
       </TableRow>
@@ -205,24 +204,24 @@ class SampleUpload extends Component {
         {this.props.authorisedActivities.includes(
           "VIEW_SAMPLE_LOAD_PROGRESS"
         ) && (
-            <>
-              <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
-                Uploaded Sample Files
-              </Typography>
-              <TableContainer component={Paper}>
-                <Table id="sampleFilesList">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>File Name</TableCell>
-                      <TableCell>Date Uploaded</TableCell>
-                      <TableCell align="right">Status</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>{jobTableRows}</TableBody>
-                </Table>
-              </TableContainer>
-            </>
-          )}
+          <>
+            <Typography variant="h6" color="inherit" style={{ marginTop: 20 }}>
+              Uploaded Sample Files
+            </Typography>
+            <TableContainer component={Paper}>
+              <Table id="sampleFilesList">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>File Name</TableCell>
+                    <TableCell>Date Uploaded</TableCell>
+                    <TableCell align="right">Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>{jobTableRows}</TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
         {this.props.authorisedActivities.includes("LOAD_SAMPLE") && (
           <>
             <input


### PR DESCRIPTION
# Motivation and Context
The set limit on the server side support tool is 100mb,  make the UI respect this

# What has changed
check the size of the file being uploaded

# How to test?
Create some different file sizes and try them out

# Links
https://trello.com/c/wdsQgdxO/494-490mb-sample-file-in-support-tool-spike
