### PR TITLE
Add limits to case search

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyCasesEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SurveyCasesEndpoint.java
@@ -97,6 +97,8 @@ public class SurveyCasesEndpoint {
       }
     }
 
+    queryStringBuilder.append(" LIMIT 100");
+
     return namedParameterJdbcTemplate.query(
         queryStringBuilder.toString(), namedParameters, caseRowMapper);
   }

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -236,7 +236,7 @@ class SurveyCaseSearch extends Component {
               color="inherit"
               style={{ marginTop: 10, marginBottom: 10 }}
             >
-              Warning, there are too many search results to show
+              Search results are limited to 100, so there may be more matching cases
             </Typography>
           )}
         {!this.state.caseSearchTerm && !this.state.isWaitingForResults && (

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -236,7 +236,8 @@ class SurveyCaseSearch extends Component {
               color="inherit"
               style={{ marginTop: 10, marginBottom: 10 }}
             >
-              Search results are limited to 100, so there may be more matching cases
+              Search results are limited to 100, so there may be more matching
+              cases
             </Typography>
           )}
         {!this.state.caseSearchTerm && !this.state.isWaitingForResults && (

--- a/ui/src/SurveyCaseSearch.js
+++ b/ui/src/SurveyCaseSearch.js
@@ -228,6 +228,17 @@ class SurveyCaseSearch extends Component {
             ":
           </Typography>
         )}
+        {this.state.caseSearchTerm &&
+          !this.state.isWaitingForResults &&
+          this.state.caseSearchResults.length === 100 && (
+            <Typography
+              variant="h6"
+              color="inherit"
+              style={{ marginTop: 10, marginBottom: 10 }}
+            >
+              Warning, there are too many search results to show
+            </Typography>
+          )}
         {!this.state.caseSearchTerm && !this.state.isWaitingForResults && (
           <Typography
             variant="h5"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to add a limit so that its not possible for an excessive amount of cases to be returned in the search.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Limit of 100 added to the search api endpoint
Warning that shows up in front end if this limit is in place
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
make build
make up
create a survey that has enough cases in that when using a search term will return more than 100 of them
check that only 100 show up
check that you are warned you're not seeing all cases
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/4nYKTnmj/499-add-safety-limit-to-support-tool-case-search-query-5
# Screenshots (if appropriate):
