### PR TITLE
Quick process refresh

### DIFF
--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -165,6 +165,10 @@ class SampleUpload extends Component {
     fetch(`/api/job/${this.state.selectedJob}/process`, {
       method: "POST",
     });
+
+    alert(
+      "Posted Process Job successfully, because of complexities this may take a while to update, but don't go mashing the Process Btn"
+    );
   };
 
   onCancelJob = () => {

--- a/ui/src/SampleUpload.js
+++ b/ui/src/SampleUpload.js
@@ -164,11 +164,7 @@ class SampleUpload extends Component {
   onProcessJob = () => {
     fetch(`/api/job/${this.state.selectedJob}/process`, {
       method: "POST",
-    });
-
-    alert(
-      "Posted Process Job successfully, because of complexities this may take a while to update, but don't go mashing the Process Btn"
-    );
+    }).then(() => this.getJobs());
   };
 
   onCancelJob = () => {


### PR DESCRIPTION
# Motivation and Context
Previously you hit 'Process' and it could be 10 seconds before anything happened on screen 'have I hit it or not? doubts creep in'

# What has changed
Turns out it's easiest to stick a .then(()=>this.getjobs) on the end of it.  This makes it refresh once it's updated state - so it all works nicely,

# How to test?
Upload some files and check on/new version for speed difference

