### PR TITLE
delete error job rows after download

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -9,7 +9,6 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -109,7 +108,6 @@ public class JobEndpoint {
 
   @GetMapping(value = "/{id}/error")
   @ResponseBody
-  @Transactional
   public String getErrorCsv(
       @PathVariable("id") UUID id,
       @Value("#{request.getAttribute('userEmail')}") String userEmail,
@@ -153,7 +151,6 @@ public class JobEndpoint {
 
   @GetMapping(value = "/{id}/errorDetail")
   @ResponseBody
-  @Transactional
   public String getErrorDetailCsv(
       @PathVariable("id") UUID id,
       @Value("#{request.getAttribute('userEmail')}") String userEmail,

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/JobEndpoint.java
@@ -9,6 +9,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,6 +53,8 @@ public class JobEndpoint {
   private final CollectionExerciseRepository collectionExerciseRepository;
   private final UserIdentity userIdentity;
   private final JobTypeHelper jobTypeHelper;
+
+  private final List<UUID> downloadableErroredJobIds = new ArrayList<>();
 
   @Value("${file-upload-storage-path}")
   private String fileUploadStoragePath;
@@ -108,6 +111,7 @@ public class JobEndpoint {
 
   @GetMapping(value = "/{id}/error")
   @ResponseBody
+  @Transactional
   public String getErrorCsv(
       @PathVariable("id") UUID id,
       @Value("#{request.getAttribute('userEmail')}") String userEmail,
@@ -146,11 +150,19 @@ public class JobEndpoint {
       throw new RuntimeException(e);
     }
 
+    if (downloadableErroredJobIds.contains(job.getId())) {
+      jobRowRepository.deleteByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR);
+      downloadableErroredJobIds.remove(job.getId());
+    } else {
+      downloadableErroredJobIds.add(job.getId());
+    }
+
     return csvContent;
   }
 
   @GetMapping(value = "/{id}/errorDetail")
   @ResponseBody
+  @Transactional
   public String getErrorDetailCsv(
       @PathVariable("id") UUID id,
       @Value("#{request.getAttribute('userEmail')}") String userEmail,
@@ -188,6 +200,13 @@ public class JobEndpoint {
       csvContent = stringWriter.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+
+    if (downloadableErroredJobIds.contains(job.getId())) {
+      jobRowRepository.deleteByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR);
+      downloadableErroredJobIds.remove(job.getId());
+    } else {
+      downloadableErroredJobIds.add(job.getId());
     }
 
     return csvContent;


### PR DESCRIPTION
# Motivation and Context
JobRows  with status `VALIDATED_ERROR` are never deleted from the job_row table, to enable the errors to be downloaded, however this causes a buildup of rows over time

# What has changed
Job rows are now deleted once both error CSVs have been downloaded.

# How to test?

- Load a sample with bad rows
- Process or cancel it
- Check that there are VALIDATED_ERROR rows in the job_row table
- Download one error CSV
- Check that the above rows are still present
- Download the other error CSV
- Check that the above rows are now gone

