### PR TITLE
995 Make Collection Exercise selection mandatory for Case Search

### DIFF
--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -44,7 +44,9 @@ class SurveySampleSearch extends Component {
   };
 
   onSearch = async () => {
-    if (!this.state.selectedCollectionExercise) {
+    if (
+      !this.props.searchTermValidator(this.state.selectedCollectionExercise)
+    ) {
       this.setState({ searchCollectionExerciseError: true });
       return;
     }

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -81,6 +81,7 @@ class SurveySampleSearch extends Component {
   onFilterCollectionExercise = (event) => {
     this.setState({
       selectedCollectionExercise: event.target.value,
+      searchCollectionExerciseError: false,
     });
   };
 
@@ -136,6 +137,7 @@ class SurveySampleSearch extends Component {
       <div id="sampleSearchDiv">
         <div id="searchCollexAndTextDiv" style={{ margin: 10 }}>
           <FormControl
+            error={this.state.searchCollectionExerciseError}
             style={{
               minWidth: 200,
               marginLeft: 10,
@@ -143,11 +145,10 @@ class SurveySampleSearch extends Component {
               padding: 0,
             }}
           >
-            <InputLabel>Collection Exercise</InputLabel>
+            <InputLabel required>Collection Exercise</InputLabel>
             <Select
               onChange={this.onFilterCollectionExercise}
               value={this.state.selectedCollectionExercise}
-              error={this.state.searchCollectionExerciseError}
             >
               {collectionExerciseMenuItems}
             </Select>

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -61,9 +61,7 @@ class SurveySampleSearch extends Component {
       this.props.surveyId
     }?searchTerm=${encodeURIComponent(this.state.searchTerm)}`;
 
-    if (this.state.selectedCollectionExercise) {
-      searchUrl += `&collexId=${this.state.selectedCollectionExercise}`;
-    }
+    searchUrl += `&collexId=${this.state.selectedCollectionExercise}`;
 
     if (this.state.selectedRefusalFilter) {
       searchUrl += `&refusal=${this.state.selectedRefusalFilter}`;

--- a/ui/src/SurveySampleSearch.js
+++ b/ui/src/SurveySampleSearch.js
@@ -22,6 +22,7 @@ class SurveySampleSearch extends Component {
     selectedRefusalFilter: "",
     selectedInvalidFilter: "",
     searchTerm: "",
+    searchCollectionExerciseError: false,
   };
 
   componentDidMount() {
@@ -43,6 +44,12 @@ class SurveySampleSearch extends Component {
   };
 
   onSearch = async () => {
+    if (!this.state.selectedCollectionExercise) {
+      this.setState({ searchCollectionExerciseError: true });
+      return;
+    }
+    this.setState({ searchCollectionExerciseError: false });
+
     if (!this.props.searchTermValidator(this.state.searchTerm)) {
       this.setState({ searchTermFailedValidation: true });
       return;
@@ -96,7 +103,6 @@ class SurveySampleSearch extends Component {
       </MenuItem>
     );
     let collectionExerciseMenuItems = [];
-    collectionExerciseMenuItems.push(noFilterMenuItem);
     collectionExerciseMenuItems.push(
       this.props.collectionExercises.map((collex) => (
         <MenuItem key={collex.name} value={collex.id}>
@@ -128,7 +134,24 @@ class SurveySampleSearch extends Component {
 
     return (
       <div id="sampleSearchDiv">
-        <div id="searchTxtDiv" style={{ margin: 10 }}>
+        <div id="searchCollexAndTextDiv" style={{ margin: 10 }}>
+          <FormControl
+            style={{
+              minWidth: 200,
+              marginLeft: 10,
+              marginRight: 20,
+              padding: 0,
+            }}
+          >
+            <InputLabel>Collection Exercise</InputLabel>
+            <Select
+              onChange={this.onFilterCollectionExercise}
+              value={this.state.selectedCollectionExercise}
+              error={this.state.searchCollectionExerciseError}
+            >
+              {collectionExerciseMenuItems}
+            </Select>
+          </FormControl>
           <TextField
             required
             style={{ minWidth: SEARCH_FIELD_WIDTH }}
@@ -151,22 +174,6 @@ class SurveySampleSearch extends Component {
               Optional search filters:
             </Typography>
           </Box>
-          <FormControl
-            style={{
-              minWidth: 200,
-              marginLeft: 10,
-              marginRight: 20,
-              padding: 0,
-            }}
-          >
-            <InputLabel>Collection Exercise</InputLabel>
-            <Select
-              onChange={this.onFilterCollectionExercise}
-              value={this.state.selectedCollectionExercise}
-            >
-              {collectionExerciseMenuItems}
-            </Select>
-          </FormControl>
 
           <FormControl
             style={{ minWidth: 200, marginLeft: 20, marginRight: 20 }}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to guard against broad data retrieval when a user searches for all cases. This can be done by restricting to a collection exercise ID (primary key) in the search.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated the case search page

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure the case search still works as expected. You should now be prevented from searching without selecting a collection exercise ID

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/DuRJxKbA
