### PR TITLE
1043 govnotify create an additional service

### DIFF
--- a/dummy-notify-config.json
+++ b/dummy-notify-config.json
@@ -1,0 +1,12 @@
+{
+  "Office_for_National_Statistics_surveys_UKHSA": {
+    "base-url": "http://notifystub:5000",
+    "api-key": "dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7"
+  },
+  "test_service": {
+    "base-url": "http://notifystub:5000",
+    "api-key": "TESTSERVICEKEY-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe8"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.17.0</version>
+      <version>4.18.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.18.0-SNAPSHOT</version>
+      <version>4.18.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/EmailTemplateEndpoint.java
@@ -51,6 +51,7 @@ public class EmailTemplateEndpoint {
               emailTemplateDto.setNotifyTemplateId(emailTemplate.getNotifyTemplateId());
               emailTemplateDto.setDescription(emailTemplate.getDescription());
               emailTemplateDto.setMetadata(emailTemplate.getMetadata());
+              emailTemplateDto.setNotifyServiceRef(emailTemplate.getNotifyServiceRef());
               return emailTemplateDto;
             })
         .collect(Collectors.toList());
@@ -71,6 +72,7 @@ public class EmailTemplateEndpoint {
     emailTemplate.setNotifyTemplateId(emailTemplateDto.getNotifyTemplateId());
     emailTemplate.setDescription(emailTemplateDto.getDescription());
     emailTemplate.setMetadata(emailTemplateDto.getMetadata());
+    emailTemplate.setNotifyServiceRef(emailTemplateDto.getNotifyServiceRef());
 
     emailTemplateRepository.saveAndFlush(emailTemplate);
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/NotifyServiceRefEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/NotifyServiceRefEndpoint.java
@@ -1,23 +1,21 @@
 package uk.gov.ons.ssdc.supporttool.endpoint;
 
+import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.LIST_EMAIL_TEMPLATES;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
-import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
-
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
-
-import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.LIST_EMAIL_TEMPLATES;
-import static uk.gov.ons.ssdc.common.model.entity.UserGroupAuthorisedActivityType.LIST_EXPORT_FILE_DESTINATIONS;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ssdc.supporttool.security.UserIdentity;
+import uk.gov.ons.ssdc.supporttool.utility.ObjectMapperFactory;
 
 @RestController
 @RequestMapping(value = "/api/notifyServiceRefs")
@@ -27,7 +25,7 @@ public class NotifyServiceRefEndpoint {
 
   private final UserIdentity userIdentity;
 
-  @Value("${notifyserviceconfig}")
+  @Value("${notifyserviceconfigfile}")
   private String configFile;
 
   private Set<String> notifyServiceRefs = null;

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/SmsTemplateEndpoint.java
@@ -50,6 +50,7 @@ public class SmsTemplateEndpoint {
               smsTemplateDto.setNotifyTemplateId(smsTemplate.getNotifyTemplateId());
               smsTemplateDto.setDescription(smsTemplate.getDescription());
               smsTemplateDto.setMetadata(smsTemplate.getMetadata());
+              smsTemplateDto.setNotifyServiceRef(smsTemplate.getNotifyServiceRef());
               return smsTemplateDto;
             })
         .collect(Collectors.toList());
@@ -70,6 +71,7 @@ public class SmsTemplateEndpoint {
     smsTemplate.setNotifyTemplateId(smsTemplateDto.getNotifyTemplateId());
     smsTemplate.setDescription(smsTemplateDto.getDescription());
     smsTemplate.setMetadata(smsTemplateDto.getMetadata());
+    smsTemplate.setNotifyServiceRef(smsTemplateDto.getNotifyServiceRef());
 
     smsTemplateRepository.saveAndFlush(smsTemplate);
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/EmailTemplateDto.java
@@ -13,6 +13,7 @@ public class EmailTemplateDto {
   private UUID notifyTemplateId;
   private String description;
   private Object metadata;
+  private String notifyServiceRef;
 
   public EmailTemplateDto(EmailTemplate emailTemplate) {
     packCode = emailTemplate.getPackCode();
@@ -20,5 +21,6 @@ public class EmailTemplateDto {
     notifyTemplateId = emailTemplate.getNotifyTemplateId();
     description = emailTemplate.getDescription();
     metadata = emailTemplate.getMetadata();
+    notifyServiceRef = emailTemplate.getNotifyServiceRef();
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/SmsTemplateDto.java
@@ -13,6 +13,7 @@ public class SmsTemplateDto {
   private UUID notifyTemplateId;
   private String description;
   private Object metadata;
+  private String notifyServiceRef;
 
   public SmsTemplateDto(SmsTemplate smsTemplate) {
     packCode = smsTemplate.getPackCode();
@@ -20,5 +21,6 @@ public class SmsTemplateDto {
     notifyTemplateId = smsTemplate.getNotifyTemplateId();
     description = smsTemplate.getDescription();
     metadata = smsTemplate.getMetadata();
+    notifyServiceRef = smsTemplate.getNotifyServiceRef();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ dummyuseridentity: dummy@fake-email.com
 dummysuperuseridentity: dummy@fake-email.com
 
 exportfiledestinationconfigfile: dummy-export-file-destination-config.json
-notifyserviceconfig: dummy-notify-config.json
+notifyserviceconfigfile: dummy-notify-config.json
 queueconfig:
   new-case-topic: event_new-case
   print-fulfilment-topic: event_print-fulfilment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ dummyuseridentity: dummy@fake-email.com
 dummysuperuseridentity: dummy@fake-email.com
 
 exportfiledestinationconfigfile: dummy-export-file-destination-config.json
-
+notifyserviceconfig: dummy-notify-config.json
 queueconfig:
   new-case-topic: event_new-case
   print-fulfilment-topic: event_print-fulfilment

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/endpoint/AllEndpointsIT.java
@@ -373,6 +373,8 @@ class AllEndpointsIT {
           smsTemplateDto.setPackCode("TEST_" + UUID.randomUUID());
           smsTemplateDto.setDescription("Test description");
           smsTemplateDto.setMetadata(Map.of("foo", "bar"));
+          smsTemplateDto.setNotifyServiceRef("test_service");
+
           return smsTemplateDto;
         });
   }
@@ -393,6 +395,7 @@ class AllEndpointsIT {
           emailTemplateDto.setPackCode("TEST_" + UUID.randomUUID());
           emailTemplateDto.setDescription("Test description");
           emailTemplateDto.setMetadata(Map.of("foo", "bar"));
+          emailTemplateDto.setNotifyServiceRef("test_service");
           return emailTemplateDto;
         });
   }

--- a/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
+++ b/src/test/java/uk/gov/ons/ssdc/supporttool/testhelper/IntegrationTestHelper.java
@@ -231,6 +231,7 @@ public class IntegrationTestHelper {
     smsTemplate.setTemplate(new String[] {"foo", "bar"});
     smsTemplate.setNotifyTemplateId(UUID.randomUUID());
     smsTemplate.setDescription("Test description");
+    smsTemplate.setNotifyServiceRef("test_service");
     smsTemplate = smsTemplateRepository.saveAndFlush(smsTemplate);
 
     EmailTemplate emailTemplate = new EmailTemplate();
@@ -238,6 +239,7 @@ public class IntegrationTestHelper {
     emailTemplate.setTemplate(new String[] {"foo", "bar"});
     emailTemplate.setNotifyTemplateId(UUID.randomUUID());
     emailTemplate.setDescription("Test description");
+    emailTemplate.setNotifyServiceRef("test_service");
     emailTemplate = emailTemplateRepository.saveAndFlush(emailTemplate);
 
     User user = setupDummyUser(UUID.randomUUID());

--- a/ui/src/EmailTemplateList.js
+++ b/ui/src/EmailTemplateList.js
@@ -11,7 +11,11 @@ import {
   DialogContent,
   TextField,
   Paper,
-  Typography, MenuItem, FormControl, InputLabel, Select,
+  Typography,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Select,
 } from "@material-ui/core";
 import { errorAlert, getAuthorisedActivities } from "./Utils";
 
@@ -51,8 +55,8 @@ class EmailTemplateList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    this.getEmailTemplates(authorisedActivities)
-    this.getNotifyServiceRefs(authorisedActivities)
+    this.getEmailTemplates(authorisedActivities);
+    this.getNotifyServiceRefs(authorisedActivities);
   };
 
   getNotifyServiceRefs = async (authorisedActivities) => {
@@ -74,7 +78,7 @@ class EmailTemplateList extends Component {
     const templateJson = await response.json();
 
     this.setState({ emailTemplates: templateJson });
-  }
+  };
 
   openEmailTemplateDialog = () => {
     this.createEmailTemplateInProgress = false;
@@ -270,7 +274,7 @@ class EmailTemplateList extends Component {
       description: this.state.description,
       template: JSON.parse(this.state.template),
       metadata: metadata,
-      notifyServiceRef: this.state.notifyServiceRef
+      notifyServiceRef: this.state.notifyServiceRef,
     };
 
     const response = await fetch("/api/emailTemplates", {
@@ -317,12 +321,13 @@ class EmailTemplateList extends Component {
       </TableRow>
     ));
 
-    const notifyConfigMenuItems =
-        this.state.notifyServiceRefs.map((supplier) => (
-            <MenuItem key={supplier} value={supplier} id={supplier}>
-              {supplier}
-            </MenuItem>
-        ));
+    const notifyConfigMenuItems = this.state.notifyServiceRefs.map(
+      (supplier) => (
+        <MenuItem key={supplier} value={supplier} id={supplier}>
+          {supplier}
+        </MenuItem>
+      ),
+    );
 
     return (
       <>
@@ -422,22 +427,22 @@ class EmailTemplateList extends Component {
                   value={this.state.newTemplateMetadata}
                 />
                 <FormControl
-                    required
-                    fullWidth={true}
-                    style={{ marginTop: 10 }}
-                    id="form"
+                  required
+                  fullWidth={true}
+                  style={{ marginTop: 10 }}
+                  id="form"
                 >
                   <InputLabel>Notify services</InputLabel>
                   <Select
-                      onChange={this.onNotifyServiceRefChange}
-                      value={this.state.notifyServiceRef}
-                      error={this.state.notifyServiceRefValidationError}
-                      id="EmailNotifyServiceRef"
+                    onChange={this.onNotifyServiceRefChange}
+                    value={this.state.notifyServiceRef}
+                    error={this.state.notifyServiceRefValidationError}
+                    id="EmailNotifyServiceRef"
                   >
                     {notifyConfigMenuItems}
                   </Select>
                 </FormControl>
-            </div>
+              </div>
               <div style={{ marginTop: 10 }}>
                 <Button
                   onClick={this.onCreateEmailTemplate}

--- a/ui/src/EmailTemplateList.js
+++ b/ui/src/EmailTemplateList.js
@@ -56,6 +56,7 @@ class EmailTemplateList extends Component {
   };
 
   getNotifyServiceRefs = async (authorisedActivities) => {
+    // TODO Create new activity called LIST_NOTIFY_SERVICES
     if (!authorisedActivities.includes("LIST_EMAIL_TEMPLATES")) return;
 
     const supplierResponse = await fetch("/api/notifyServiceRefs");
@@ -133,14 +134,6 @@ class EmailTemplateList extends Component {
     this.setState({
       notifyTemplateId: event.target.value,
       notifyTemplateIdValidationError: resetValidation,
-    });
-  };
-
-  onNotifyServiceRefChange = (event) => {
-
-    this.setState({
-      NotifyServiceRef: event.target.value,
-      NotifyServiceRefValidationError: false,
     });
   };
 
@@ -439,7 +432,7 @@ class EmailTemplateList extends Component {
                       onChange={this.onNotifyServiceRefChange}
                       value={this.state.notifyServiceRef}
                       error={this.state.notifyServiceRefValidationError}
-                      id="notifyServiceRef"
+                      id="EmailNotifyServiceRef"
                   >
                     {notifyConfigMenuItems}
                   </Select>

--- a/ui/src/SmsTemplatesList.js
+++ b/ui/src/SmsTemplatesList.js
@@ -11,7 +11,7 @@ import {
   DialogContent,
   TextField,
   Paper,
-  Typography,
+  Typography, MenuItem, FormControl, InputLabel, Select,
 } from "@material-ui/core";
 import { errorAlert, getAuthorisedActivities } from "./Utils";
 
@@ -22,6 +22,8 @@ class SmsTemplatesList extends Component {
     createSmsTemplateError: "",
     createSMSTemplatePackCodeError: "",
     authorisedActivities: [],
+    notifyServiceRef: "",
+    notifyServiceRefs: [],
     notifyTemplateId: "",
     packCode: "",
     description: "",
@@ -48,13 +50,30 @@ class SmsTemplatesList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
+    this.getSmsTemplates(authorisedActivities)
+    this.getNotifyServiceRefs(authorisedActivities)
+  };
+  getNotifyServiceRefs = async (authorisedActivities) => {
+    // TODO Create new activity called LIST_NOTIFY_SERVICES
+
+    if (!authorisedActivities.includes("LIST_EMAIL_TEMPLATES")) return;
+
+    const supplierResponse = await fetch("/api/notifyServiceRefs");
+    const supplierJson = await supplierResponse.json();
+
+    this.setState({
+      notifyServiceRefs: supplierJson,
+    });
+  };
+  getSmsTemplates = async (authorisedActivities) => {
     if (!authorisedActivities.includes("LIST_SMS_TEMPLATES")) return;
 
     const response = await fetch("/api/smsTemplates");
     const templateJson = await response.json();
 
     this.setState({ smsTemplates: templateJson });
-  };
+  }
+
 
   openSmsTemplateDialog = () => {
     this.createSmsTemplateInProgress = false;
@@ -66,6 +85,7 @@ class SmsTemplatesList extends Component {
       template: "",
       newTemplateMetadata: "",
       notifyTemplateId: "",
+      notifyServiceRef: "",
       packCodeValidationError: false,
       descriptionValidationError: false,
       templateValidationError: false,
@@ -73,6 +93,7 @@ class SmsTemplatesList extends Component {
       newTemplateMetadataValidationError: false,
       notifyTemplateIdValidationError: false,
       createSmsTemplateDialogDisplayed: true,
+      notifyServiceRefValidationError: false,
       createSmsTemplateError: "",
       notifyTemplateIdErrorMessage: "",
       createSMSTemplatePackCodeError: "",
@@ -166,7 +187,10 @@ class SmsTemplatesList extends Component {
         });
       }
     }
-
+    if (!this.state.notifyServiceRef.trim()) {
+      this.setState({ notifyServiceRefValidationError: true });
+      failedValidation = true;
+    }
     let metadata = null;
 
     if (this.state.newTemplateMetadata) {
@@ -192,6 +216,7 @@ class SmsTemplatesList extends Component {
       packCode: this.state.packCode,
       description: this.state.description,
       template: JSON.parse(this.state.template),
+      notifyServiceRef: this.state.notifyServiceRef,
       metadata: metadata,
     };
 
@@ -221,6 +246,13 @@ class SmsTemplatesList extends Component {
     this.setState({
       packCode: event.target.value,
       packCodeValidationError: resetValidation,
+    });
+  };
+
+  onNotifyServiceRefChange = (event) => {
+    this.setState({
+      notifyServiceRef: event.target.value,
+      notifyServiceRefValidationError: false,
     });
   };
 
@@ -276,8 +308,17 @@ class SmsTemplatesList extends Component {
         <TableCell component="th" scope="row">
           {JSON.stringify(smsTemplate.metadata)}
         </TableCell>
+        <TableCell component="th" scope="row">
+          {smsTemplate.notifyServiceRef}
+        </TableCell>
       </TableRow>
     ));
+    const notifyConfigMenuItems =
+        this.state.notifyServiceRefs.map((supplier) => (
+            <MenuItem key={supplier} value={supplier} id={supplier}>
+              {supplier}
+            </MenuItem>
+        ));
 
     return (
       <>
@@ -295,6 +336,8 @@ class SmsTemplatesList extends Component {
                     <TableCell>Template</TableCell>
                     <TableCell>Gov Notify Template ID</TableCell>
                     <TableCell>Metadata</TableCell>
+                    <TableCell>Gov Notify Service Ref</TableCell>
+
                   </TableRow>
                 </TableHead>
                 <TableBody>{smsTemplateRows}</TableBody>
@@ -370,6 +413,22 @@ class SmsTemplatesList extends Component {
                   onChange={this.onNewTemplateMetadataChange}
                   value={this.state.newTemplateMetadata}
                 />
+                <FormControl
+                    required
+                    fullWidth={true}
+                    style={{ marginTop: 10 }}
+                    id="form"
+                >
+                  <InputLabel>Notify services</InputLabel>
+                  <Select
+                      onChange={this.onNotifyServiceRefChange}
+                      value={this.state.notifyServiceRef}
+                      error={this.state.notifyServiceRefValidationError}
+                      id="SmsNotifyServiceRef"
+                  >
+                    {notifyConfigMenuItems}
+                  </Select>
+                </FormControl>
               </div>
               <div style={{ marginTop: 10 }}>
                 <Button

--- a/ui/src/SmsTemplatesList.js
+++ b/ui/src/SmsTemplatesList.js
@@ -11,7 +11,11 @@ import {
   DialogContent,
   TextField,
   Paper,
-  Typography, MenuItem, FormControl, InputLabel, Select,
+  Typography,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Select,
 } from "@material-ui/core";
 import { errorAlert, getAuthorisedActivities } from "./Utils";
 
@@ -50,8 +54,8 @@ class SmsTemplatesList extends Component {
   };
 
   refreshDataFromBackend = async (authorisedActivities) => {
-    this.getSmsTemplates(authorisedActivities)
-    this.getNotifyServiceRefs(authorisedActivities)
+    this.getSmsTemplates(authorisedActivities);
+    this.getNotifyServiceRefs(authorisedActivities);
   };
   getNotifyServiceRefs = async (authorisedActivities) => {
     // TODO Create new activity called LIST_NOTIFY_SERVICES
@@ -72,8 +76,7 @@ class SmsTemplatesList extends Component {
     const templateJson = await response.json();
 
     this.setState({ smsTemplates: templateJson });
-  }
-
+  };
 
   openSmsTemplateDialog = () => {
     this.createSmsTemplateInProgress = false;
@@ -313,12 +316,13 @@ class SmsTemplatesList extends Component {
         </TableCell>
       </TableRow>
     ));
-    const notifyConfigMenuItems =
-        this.state.notifyServiceRefs.map((supplier) => (
-            <MenuItem key={supplier} value={supplier} id={supplier}>
-              {supplier}
-            </MenuItem>
-        ));
+    const notifyConfigMenuItems = this.state.notifyServiceRefs.map(
+      (supplier) => (
+        <MenuItem key={supplier} value={supplier} id={supplier}>
+          {supplier}
+        </MenuItem>
+      ),
+    );
 
     return (
       <>
@@ -337,7 +341,6 @@ class SmsTemplatesList extends Component {
                     <TableCell>Gov Notify Template ID</TableCell>
                     <TableCell>Metadata</TableCell>
                     <TableCell>Gov Notify Service Ref</TableCell>
-
                   </TableRow>
                 </TableHead>
                 <TableBody>{smsTemplateRows}</TableBody>
@@ -414,17 +417,17 @@ class SmsTemplatesList extends Component {
                   value={this.state.newTemplateMetadata}
                 />
                 <FormControl
-                    required
-                    fullWidth={true}
-                    style={{ marginTop: 10 }}
-                    id="form"
+                  required
+                  fullWidth={true}
+                  style={{ marginTop: 10 }}
+                  id="form"
                 >
                   <InputLabel>Notify services</InputLabel>
                   <Select
-                      onChange={this.onNotifyServiceRefChange}
-                      value={this.state.notifyServiceRef}
-                      error={this.state.notifyServiceRefValidationError}
-                      id="SmsNotifyServiceRef"
+                    onChange={this.onNotifyServiceRefChange}
+                    value={this.state.notifyServiceRef}
+                    error={this.state.notifyServiceRefValidationError}
+                    id="SmsNotifyServiceRef"
                   >
                     {notifyConfigMenuItems}
                   </Select>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment the Gov Notify service we currently use has UKHSA branding on it which means we can't use it if we needed to onboard another survey. This PR adds the functionality to be able to supply multiple gov notify services by adding them to a json file which can be passed in.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
-  Email templates and sms templates now show the service they're under
- When creating email templates and sms templates, you need to supply the gov notify service they are using 
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run make build and all tests should pass
- Run with the other branches on the card and make sure it all works as expected
- Update the ddl with the ddl branch
- In support tool, create a email and sms template and try creating some with different services.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/gL7KBQtj/)
