### PR TITLE
Show correct reschedule action rule datetime

### DIFF
--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -58,6 +58,7 @@ class CollectionExerciseDetails extends Component {
     newUacQidMetadata: "",
     rescheduleActionRuleDisabled: false,
     actionRuleToBeUpdated: {},
+    currentTriggerDateTime: "",
     updatedTriggerDateTime: "",
     confirmRescheduleDialogDisplayed: false,
   };
@@ -210,7 +211,7 @@ class CollectionExerciseDetails extends Component {
     this.setState({
       actionRuleToBeUpdated: actionRule,
       rescheduleActionRulesDialogDisplayed: true,
-      updatedTriggerDateTime: actionRule.triggerDateTime.slice(0, 16),
+      currentTriggerDateTime: actionRule.triggerDateTime.slice(0, 16),
     });
   };
 
@@ -508,16 +509,21 @@ class CollectionExerciseDetails extends Component {
       return "";
     }
 
-    const dateISOString = this.getUpdatedTriggerDateTimeString();
+    const updatedDateISOString = this.getUpdatedTriggerDateTimeString();
+    const currentDateISOString = this.getCurrentTriggerDateTimeString();
     return `Are you sure you wish to change the date for ${
       this.state.actionRuleToBeUpdated.type
-    } from ${dateISOString.slice(0, 16).replace("T", " ")} to ${dateISOString
+    } from ${currentDateISOString.slice(0, 16).replace("T", " ")} to ${updatedDateISOString
       .slice(0, 16)
       .replace("T", " ")}?`;
   };
 
   getUpdatedTriggerDateTimeString = () => {
     return new Date(this.state.updatedTriggerDateTime).toISOString();
+  };
+
+  getCurrentTriggerDateTimeString = () => {
+    return new Date(this.state.currentTriggerDateTime).toISOString();
   };
 
   render() {

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -513,7 +513,9 @@ class CollectionExerciseDetails extends Component {
     const currentDateISOString = this.getCurrentTriggerDateTimeString();
     return `Are you sure you wish to change the date for ${
       this.state.actionRuleToBeUpdated.type
-    } from ${currentDateISOString.slice(0, 16).replace("T", " ")} to ${updatedDateISOString
+    } from ${currentDateISOString
+      .slice(0, 16)
+      .replace("T", " ")} to ${updatedDateISOString
       .slice(0, 16)
       .replace("T", " ")}?`;
   };


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the reschedule datetime is showing the same datetime twice when changing a action rule trigger datetime
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Show the updated datetime for the reschedule button
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the branch and set a action rule for the future. When rescheduling, you should be able to see both datetimes. 
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/biW1SiWy/)
# Screenshots (if appropriate):
