### PR TITLE
Update version of label checker and exclude patch updates from Depend…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"
@@ -11,6 +14,9 @@ updates:
     directory: "/ui"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+      - uses: docker://onsdigital/github-pr-label-checker:v1.6.13
         with:
           one_of: breaking change,feature,patch
           none_of: do not merge,work in progress

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@material-ui/core": "^4.11.4",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.60",
-        "axios": "^1.6.2",
+        "axios": "^1.6.5",
         "babel-eslint": "^10.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -6534,11 +6534,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -9927,9 +9927,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
-    "axios": "^1.6.2",
+    "axios": "^1.6.5",
     "babel-eslint": "^10.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
# Motivation and Context
- The label checker is way out of date and has features that are no longer supported
- Dependabot has been raising more PRs than we can deal with

# What has changed
- Updated the version of the label checker to the latest available (1.6.13)
- Excluded patch updates in the Dependabot config

# How to test?
- Label checker should work as normal
- We should in future see less Dependabot PRs being raised (this has already been tested for a while in caseprocessor)

# Links
https://trello.com/c/TDpQHGaw