### PR TITLE
Update node version in GH Actions

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -26,7 +26,7 @@ jobs:
       # And acquire a token for authenticating with the docker registry
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
@@ -48,7 +48,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set Up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
@@ -64,7 +64,7 @@ jobs:
         run: mvn verify jacoco:report
 
       - name: Run Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # NB: fail_ci_if_error is enabled to make any teething issues with Codecov visible.
@@ -80,10 +80,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 16
 
       - name: Update NPM
         # The setup node action links the version of NPM to the version of node

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Update NPM
         # The setup node action links the version of NPM to the version of node

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,8 @@
   },
   "overrides": {
     "nth-check@1.x": "^2.0.1",
-    "postcss": "^8.4.31"
+    "postcss": "^8.4.31",
+    "follow-redirects@1.15.5": "^1.15.6"
   },
   "engines": {
     "npm": "^10.4.0"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Node.js 16 actions are being deprecated, we need to update. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Updated Node.js version for GitHub Actions.
Also had to pin down an npm package that had a vulnerability.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See the relevant commits in the action's repos and check that our versions match:

- [actions/checkout](https://github.com/actions/checkout/commit/97a652b80035363df47baee5031ec8670b8878ac)
- [google-github-actions/auth](https://github.com/google-github-actions/auth/commit/43a59886fcb7545b65158bdc879d7b29e7f3ab05)
- [docker/login-action](https://github.com/docker/login-action/commit/3c2fe176ab3489635dda352c921ddbb8fb14b254)
- [actions/setup-java](https://github.com/actions/setup-java/commit/387ac29b308b003ca37ba93a6cab5eb57c8f5f93)
- [codecov/codecov-action](https://github.com/codecov/codecov-action/commit/0cf8684c821546a4e0c8c9a4cf4f21a7a0c5014b)
- [actions/setup-node](https://github.com/actions/setup-node/commit/54534a2a9ba7308e8a8995af3104899e6a95b681)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=2913&view=detail&selectedIssue=SDCSRM-374
https://trello.com/c/9Ey1O101/1388-upgrade-github-actions-version-5


# Screenshots (if appropriate):
