### PR TITLE
SDCSRM-300 Duplicate Rows For Templates Fix

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyEmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyEmailTemplateEndpoint.java
@@ -121,6 +121,18 @@ public class ActionRuleSurveyEmailTemplateEndpoint {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);
     }
 
+    if (actionRuleSurveyEmailTemplateRepository
+            .countActionRuleSurveyEmailTemplateByEmailTemplateAndAndSurvey(emailTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey email template, Email Template already exists for survey");
+      return new ResponseEntity<>(
+          "Export Email already exists for survey", HttpStatus.CONFLICT);
+    }
+
     ActionRuleSurveyEmailTemplate actionRuleSurveyEmailTemplate =
         new ActionRuleSurveyEmailTemplate();
     actionRuleSurveyEmailTemplate.setId(UUID.randomUUID());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveyExportFileTemplateEndpoint.java
@@ -115,6 +115,18 @@ public class ActionRuleSurveyExportFileTemplateEndpoint {
                       HttpStatus.BAD_REQUEST, "Export File template not found");
                 });
 
+    if (actionRuleSurveyExportFileTemplateRepository
+            .countActionRuleSurveyExportFileTemplateByExportFileTemplateAndSurvey(
+                exportFileTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey Export File template, Export File Template already exists for survey");
+      return new ResponseEntity<>("Export File Template already exists for survey", HttpStatus.CONFLICT);
+    }
+
     Optional<String> errorOpt = validate(survey, Set.of(exportFileTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       log.with("httpStatus", HttpStatus.BAD_REQUEST)

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleSurveySmsTemplateEndpoint.java
@@ -109,6 +109,17 @@ public class ActionRuleSurveySmsTemplateEndpoint {
                       HttpStatus.BAD_REQUEST, "SMS template not found");
                 });
 
+    if (actionRuleSurveySmsTemplateRepository
+            .countActionRuleSurveySmsTemplateBySmsTemplateAndSurvey(smsTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey sms template, SMS Template already exists for survey");
+      return new ResponseEntity<>("SMS Template already exists for survey", HttpStatus.CONFLICT);
+    }
+
     Optional<String> errorOpt = validate(survey, Set.of(smsTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       log.with("httpStatus", HttpStatus.BAD_REQUEST)

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyEmailTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyEmailTemplateEndpoint.java
@@ -114,6 +114,17 @@ public class FulfilmentSurveyEmailTemplateEndpoint {
                       HttpStatus.BAD_REQUEST, "Email template not found");
                 });
 
+    if (fulfilmentSurveyEmailTemplateRepository
+            .countFulfilmentSurveyEmailTemplateByEmailTemplateAndSurvey(emailTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey email template, Email Template already exists for survey");
+      return new ResponseEntity<>("Email Template already exists for survey", HttpStatus.CONFLICT);
+    }
+
     Optional<String> errorOpt = validate(survey, Set.of(emailTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveyExportFileTemplateEndpoint.java
@@ -119,6 +119,19 @@ public class FulfilmentSurveyExportFileTemplateEndpoint {
                       HttpStatus.BAD_REQUEST, "Export file template not found");
                 });
 
+    if (fulfilmentSurveyExportFileTemplateRepository
+            .countFulfilmentSurveyExportFileTemplateByExportFileTemplateAndSurvey(
+                exportFileTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey export file template, Export File Template already exists for survey");
+      return new ResponseEntity<>(
+          "Export File Template already exists for survey", HttpStatus.CONFLICT);
+    }
+
     Optional<String> errorOpt = validate(survey, Set.of(exportFileTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/FulfilmentSurveySmsTemplateEndpoint.java
@@ -113,6 +113,17 @@ public class FulfilmentSurveySmsTemplateEndpoint {
                       HttpStatus.BAD_REQUEST, "SMS template not found");
                 });
 
+    if (fulfilmentSurveySmsTemplateRepository
+            .countFulfilmentSurveySmsTemplateBySmsTemplateAndSurvey(smsTemplate, survey)
+        != 0) {
+      log.with("httpStatus", HttpStatus.BAD_REQUEST)
+          .with("packCode", allowTemplateOnSurvey.getPackCode())
+          .with("userEmail", userEmail)
+          .warn(
+              "Failed to create action rule survey sms template, SMS Template already exists for survey");
+      return new ResponseEntity<>("SMS Template already exists for survey", HttpStatus.CONFLICT);
+    }
+
     Optional<String> errorOpt = validate(survey, Set.of(smsTemplate.getTemplate()));
     if (errorOpt.isPresent()) {
       return new ResponseEntity<>(errorOpt.get(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyEmailTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyEmailTemplateRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveyEmailTemplate;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface ActionRuleSurveyEmailTemplateRepository
     extends JpaRepository<ActionRuleSurveyEmailTemplate, UUID> {
   List<ActionRuleSurveyEmailTemplate> findBySurvey(Survey survey);
+
+  int countActionRuleSurveyEmailTemplateByEmailTemplateAndAndSurvey(
+      EmailTemplate emailTemplate, Survey survey);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyExportFileTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveyExportFileTemplateRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveyExportFileTemplate;
+import uk.gov.ons.ssdc.common.model.entity.ExportFileTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface ActionRuleSurveyExportFileTemplateRepository
     extends JpaRepository<ActionRuleSurveyExportFileTemplate, UUID> {
   List<ActionRuleSurveyExportFileTemplate> findBySurvey(Survey survey);
+
+  int countActionRuleSurveyExportFileTemplateByExportFileTemplateAndSurvey(
+      ExportFileTemplate exportFileTemplate, Survey survey);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/ActionRuleSurveySmsTemplateRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.ActionRuleSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface ActionRuleSurveySmsTemplateRepository
     extends JpaRepository<ActionRuleSurveySmsTemplate, UUID> {
   List<ActionRuleSurveySmsTemplate> findBySurvey(Survey survey);
+
+  int countActionRuleSurveySmsTemplateBySmsTemplateAndSurvey(
+      SmsTemplate smsTemplate, Survey survey);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyEmailTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyEmailTemplateRepository.java
@@ -3,10 +3,14 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyEmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface FulfilmentSurveyEmailTemplateRepository
     extends JpaRepository<FulfilmentSurveyEmailTemplate, UUID> {
   List<FulfilmentSurveyEmailTemplate> findBySurvey(Survey survey);
+
+  int countFulfilmentSurveyEmailTemplateByEmailTemplateAndSurvey(
+      EmailTemplate emailTemplate, Survey survey);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyExportFileTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveyExportFileTemplateRepository.java
@@ -3,10 +3,14 @@ package uk.gov.ons.ssdc.supporttool.model.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.ssdc.common.model.entity.ExportFileTemplate;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveyExportFileTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface FulfilmentSurveyExportFileTemplateRepository
     extends JpaRepository<FulfilmentSurveyExportFileTemplate, UUID> {
   List<FulfilmentSurveyExportFileTemplate> findBySurvey(Survey survey);
+
+  int countFulfilmentSurveyExportFileTemplateByExportFileTemplateAndSurvey(
+      ExportFileTemplate exportFileTemplate, Survey survey);
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/repository/FulfilmentSurveySmsTemplateRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ssdc.common.model.entity.FulfilmentSurveySmsTemplate;
+import uk.gov.ons.ssdc.common.model.entity.SmsTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
 
 public interface FulfilmentSurveySmsTemplateRepository
     extends JpaRepository<FulfilmentSurveySmsTemplate, UUID> {
   List<FulfilmentSurveySmsTemplate> findBySurvey(Survey survey);
+
+  int countFulfilmentSurveySmsTemplateBySmsTemplateAndSurvey(
+      SmsTemplate smsTemplate, Survey survey);
 }


### PR DESCRIPTION
# Motivation and Context
The support tool API allows the same template to be linked to the same survey multiple times, resulting in duplicate rows in the link DB table. This isn’t valid, and the API should not allow these duplications to be created.

# What has changed
- Added extra validation to the API that checks if a survey already has a template linked

# How to test?
- In the `ui/Allowed...List.js` files, comment out the ifs in each file (that are something like `if (!actionRuleExportFilePackCodes.includes(packCode))`), that are around line 60 to allow templates that already exist.
- Do `make build`
- Open support tool with the new API running in docker dev and try to duplicate a template on a survey, it should put an error message saying template already exists.

# Links
[Jira] https://jira.ons.gov.uk/browse/SDCSRM-300
