### PR TITLE
Added user email to confirm removal dialog

### DIFF
--- a/ui/src/GroupDetails.js
+++ b/ui/src/GroupDetails.js
@@ -48,6 +48,7 @@ class GroupDetails extends Component {
     surveyValidationError: false,
     userGroupPermissionId: null,
     adminIdToRemove: null,
+    adminEmailToRemove: null,
     showRemoveAdminDialog: false,
     showAddAdminToGroupDialog: false,
     newAdminUserId: "",
@@ -355,11 +356,12 @@ class GroupDetails extends Component {
     );
   };
 
-  openRemoveAdminDialog = (adminIdToRemove) => {
+  openRemoveAdminDialog = (adminToRemove) => {
     this.removeAdminInProgress = false;
 
     this.setState({
-      adminIdToRemove: adminIdToRemove,
+      adminIdToRemove: adminToRemove.id,
+      adminEmailToRemove: adminToRemove.userEmail,
       showRemoveAdminDialog: true,
     });
   };
@@ -391,6 +393,7 @@ class GroupDetails extends Component {
   closeRemoveAdminDialog = () => {
     this.setState({
       adminIdToRemove: null,
+      adminEmailToRemove: null,
       showRemoveAdminDialog: false,
     });
   };
@@ -474,7 +477,7 @@ class GroupDetails extends Component {
         <TableCell component="th" scope="row">
           <Button
             variant="contained"
-            onClick={() => this.openRemoveAdminDialog(admin.id)}
+            onClick={() => this.openRemoveAdminDialog(admin)}
           >
             Remove
           </Button>
@@ -712,7 +715,8 @@ class GroupDetails extends Component {
               </DialogTitle>
               <DialogContent>
                 <DialogContentText id="alert-dialog-description">
-                  Are you sure you wish to remove group admin?
+                  Are you sure you wish to remove group admin{" "}
+                  {this.state.adminEmailToRemove}?
                 </DialogContentText>
               </DialogContent>
               <DialogActions>

--- a/ui/src/MyGroupUserAdmin.js
+++ b/ui/src/MyGroupUserAdmin.js
@@ -31,6 +31,7 @@ class MyGroupUserAdmin extends Component {
     emailValidationError: false,
     showRemoveDialog: false,
     groupMemberIdToRemove: null,
+    groupMemberEmailToRemove: null,
     allUsers: [],
   };
 
@@ -155,11 +156,12 @@ class MyGroupUserAdmin extends Component {
     this.refreshBackendData(this.state.allUsers);
   };
 
-  openRemoveDialog = (groupMemberIdToRemove) => {
+  openRemoveDialog = (groupMemberToRemove) => {
     this.removeUserFromGroupInProgress = false;
 
     this.setState({
-      groupMemberIdToRemove: groupMemberIdToRemove,
+      groupMemberIdToRemove: groupMemberToRemove.id,
+      groupMemberEmailToRemove: groupMemberToRemove.userEmail,
       showRemoveDialog: true,
     });
   };
@@ -167,6 +169,7 @@ class MyGroupUserAdmin extends Component {
   closeRemoveDialog = () => {
     this.setState({
       groupMemberIdToRemove: null,
+      groupMemberEmailToRemove: null,
       showRemoveDialog: false,
     });
   };
@@ -201,7 +204,7 @@ class MyGroupUserAdmin extends Component {
         <TableCell component="th" scope="row">
           <Button
             variant="contained"
-            onClick={() => this.openRemoveDialog(groupMember.id)}
+            onClick={() => this.openRemoveDialog(groupMember)}
           >
             Remove
           </Button>
@@ -277,7 +280,8 @@ class MyGroupUserAdmin extends Component {
           <DialogTitle id="alert-dialog-title">{"Confirm remove?"}</DialogTitle>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">
-              Are you sure you wish to remove user from group?
+              Are you sure you wish to remove{" "}
+              {this.state.groupMemberEmailToRemove} from group?
             </DialogContentText>
           </DialogContent>
           <DialogActions>


### PR DESCRIPTION
# Motivation and Context
Currently there's no way of being certain which user you're removing from a group as the dialog popup doesn't say which it is

# What has changed
Added User's email address to the removal dialog popup for clarity

# How to test?
Try to remove a user