### PR TITLE
Display number of selected cases against each triggered action rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.19.0</version>
+      <version>4.20.0</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -124,6 +124,7 @@ public class ActionRuleEndpoint {
                   actionRuleDTO.setTriggerDateTime(actionRule.getTriggerDateTime());
                   actionRuleDTO.setHasTriggered(actionRule.isHasTriggered());
                   actionRuleDTO.setUacMetadata(actionRule.getUacMetadata());
+                  actionRuleDTO.setSelectedCaseCount(actionRule.getSelectedCaseCount());
                   return actionRuleDTO;
                 })
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
@@ -28,5 +28,5 @@ public class ActionRuleDto {
 
   private boolean hasTriggered;
 
-  private int selectedCaseCount;
+  private Integer selectedCaseCount;
 }

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/model/dto/ui/ActionRuleDto.java
@@ -27,4 +27,6 @@ public class ActionRuleDto {
   private Object uacMetadata;
 
   private boolean hasTriggered;
+
+  private int selectedCaseCount;
 }

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -625,7 +625,7 @@ class CollectionExerciseDetails extends Component {
             {actionRule.packCode}
           </TableCell>
           <TableCell component="th" scope="row">
-            {actionRule.selectedCaseCount}
+            {actionRule.hasTriggered ? actionRule.selectedCaseCount : null}
           </TableCell>
           <TableCell component="th" scope="row">
             {!actionRule.hasTriggered ? (

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -625,6 +625,9 @@ class CollectionExerciseDetails extends Component {
             {actionRule.packCode}
           </TableCell>
           <TableCell component="th" scope="row">
+            {actionRule.selectedCaseCount}
+          </TableCell>
+          <TableCell component="th" scope="row">
             {!actionRule.hasTriggered ? (
               <Button
                 variant="contained"
@@ -797,6 +800,7 @@ class CollectionExerciseDetails extends Component {
                     <TableCell>UAC Metadata</TableCell>
                     <TableCell>Classifiers</TableCell>
                     <TableCell>Pack Code</TableCell>
+                    <TableCell>Selected Cases</TableCell>
                     <TableCell></TableCell>
                   </TableRow>
                 </TableHead>


### PR DESCRIPTION
# Motivation and Context
It would be useful to be able to see how many cases each action rule has selected in the support tool UI

# What has changed
Added new column on each action rule to display the number of cases selected against it after it's triggered

# How to test?
Create a survey/CE/action rule in support tool and load a valid sample against it
Click the dry run button against the action rule and note how many cases should be picked up by that action rule
Wait for the rule to trigger and check that the number displayed against it in the 'Selected Cases' column is the same
