### PR TITLE
Sdcsrm 619 fix action rule datetime display

### DIFF
--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -979,6 +979,7 @@ class CollectionExerciseDetails extends Component {
                 />
                 <TextField
                   label="Trigger Date"
+                  id="triggerDate"
                   type="datetime-local"
                   value={this.state.newActionRuleTriggerDate}
                   onChange={this.onNewActionRuleTriggerDateChange}

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -484,7 +484,9 @@ class CollectionExerciseDetails extends Component {
   onRescheduleConfirm = async () => {
     const actionRule = this.state.actionRuleToBeUpdated;
 
-    actionRule.triggerDateTime = new Date(this.state.updatedTriggerDateTime).toISOString();
+    actionRule.triggerDateTime = new Date(
+      this.state.updatedTriggerDateTime,
+    ).toISOString();
 
     const response = await fetch("/api/actionRules", {
       method: "PUT",
@@ -560,17 +562,19 @@ class CollectionExerciseDetails extends Component {
 
     const updatedDateISOString = this.getUpdatedTriggerDateTimeString();
     const currentDateISOString = this.getCurrentTriggerDateTimeString();
-    return `Are you sure you wish to change the date for ${
-      this.state.actionRuleToBeUpdated.type
-    } from ${currentDateISOString} to ${updatedDateISOString}?`;
+    return `Are you sure you wish to change the date for ${this.state.actionRuleToBeUpdated.type} from ${currentDateISOString} to ${updatedDateISOString}?`;
   };
 
   getUpdatedTriggerDateTimeString = () => {
-    return new Date(this.state.updatedTriggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London' });
+    return new Date(this.state.updatedTriggerDateTime).toLocaleString("en-UK", {
+      timeZone: "Europe/London",
+    });
   };
 
   getCurrentTriggerDateTimeString = () => {
-    return new Date(this.state.currentTriggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London' });
+    return new Date(this.state.currentTriggerDateTime).toLocaleString("en-UK", {
+      timeZone: "Europe/London",
+    });
   };
 
   render() {
@@ -609,7 +613,12 @@ class CollectionExerciseDetails extends Component {
     );
 
     const actionRuleTableRows = sortedActionRules.map((actionRule, index) => {
-      const updatedDateTime = new Date(actionRule.triggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London', timeZoneName: 'longOffset' });
+      const updatedDateTime = new Date(
+        actionRule.triggerDateTime,
+      ).toLocaleString("en-UK", {
+        timeZone: "Europe/London",
+        timeZoneName: "longOffset",
+      });
       return (
         <TableRow key={index}>
           <TableCell component="th" scope="row">

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -562,7 +562,7 @@ class CollectionExerciseDetails extends Component {
 
     const updatedDateISOString = this.getUpdatedTriggerDateTimeString();
     const currentDateISOString = this.getCurrentTriggerDateTimeString();
-    return `Are you sure you wish to change the date for ${this.state.actionRuleToBeUpdated.type} from ${currentDateISOString} to ${updatedDateISOString}?`;
+    return `Are you sure you wish to change the date for "${this.state.actionRuleToBeUpdated.description || this.state.actionRuleToBeUpdated.type}"\n from ${currentDateISOString}\n to ${updatedDateISOString}?`;
   };
 
   getUpdatedTriggerDateTimeString = () => {
@@ -613,7 +613,7 @@ class CollectionExerciseDetails extends Component {
     );
 
     const actionRuleTableRows = sortedActionRules.map((actionRule, index) => {
-      const updatedDateTime = new Date(
+      const localisedDateTime = new Date(
         actionRule.triggerDateTime,
       ).toLocaleString("en-UK", {
         timeZone: "Europe/London",
@@ -628,7 +628,7 @@ class CollectionExerciseDetails extends Component {
             {actionRule.description}
           </TableCell>
           <TableCell component="th" scope="row" id="actionRuleDateTime">
-            {updatedDateTime}
+            {localisedDateTime}
           </TableCell>
           <TableCell component="th" scope="row">
             {!actionRule.hasTriggered &&
@@ -1056,7 +1056,7 @@ class CollectionExerciseDetails extends Component {
         <Dialog open={this.state.confirmRescheduleDialogDisplayed}>
           <DialogContent style={{ padding: 30 }}>
             <div>
-              <div>
+              <div className="display-linebreak">
                 <p style={{ marginTop: 20 }}>
                   {this.getConfirmRescheduleText()}
                 </p>

--- a/ui/src/CollectionExerciseDetails.js
+++ b/ui/src/CollectionExerciseDetails.js
@@ -231,7 +231,7 @@ class CollectionExerciseDetails extends Component {
     this.setState({
       actionRuleToBeUpdated: actionRule,
       rescheduleActionRulesDialogDisplayed: true,
-      currentTriggerDateTime: actionRule.triggerDateTime.slice(0, 16),
+      currentTriggerDateTime: actionRule.triggerDateTime,
     });
   };
 
@@ -484,7 +484,7 @@ class CollectionExerciseDetails extends Component {
   onRescheduleConfirm = async () => {
     const actionRule = this.state.actionRuleToBeUpdated;
 
-    actionRule.triggerDateTime = this.getUpdatedTriggerDateTimeString();
+    actionRule.triggerDateTime = new Date(this.state.updatedTriggerDateTime).toISOString();
 
     const response = await fetch("/api/actionRules", {
       method: "PUT",
@@ -562,19 +562,15 @@ class CollectionExerciseDetails extends Component {
     const currentDateISOString = this.getCurrentTriggerDateTimeString();
     return `Are you sure you wish to change the date for ${
       this.state.actionRuleToBeUpdated.type
-    } from ${currentDateISOString
-      .slice(0, 16)
-      .replace("T", " ")} to ${updatedDateISOString
-      .slice(0, 16)
-      .replace("T", " ")}?`;
+    } from ${currentDateISOString} to ${updatedDateISOString}?`;
   };
 
   getUpdatedTriggerDateTimeString = () => {
-    return new Date(this.state.updatedTriggerDateTime).toISOString();
+    return new Date(this.state.updatedTriggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London' });
   };
 
   getCurrentTriggerDateTimeString = () => {
-    return new Date(this.state.currentTriggerDateTime).toISOString();
+    return new Date(this.state.currentTriggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London' });
   };
 
   render() {
@@ -613,6 +609,7 @@ class CollectionExerciseDetails extends Component {
     );
 
     const actionRuleTableRows = sortedActionRules.map((actionRule, index) => {
+      const updatedDateTime = new Date(actionRule.triggerDateTime).toLocaleString('en-UK',{ timeZone: 'Europe/London', timeZoneName: 'longOffset' });
       return (
         <TableRow key={index}>
           <TableCell component="th" scope="row">
@@ -621,8 +618,8 @@ class CollectionExerciseDetails extends Component {
           <TableCell component="th" scope="row">
             {actionRule.description}
           </TableCell>
-          <TableCell component="th" scope="row">
-            {actionRule.triggerDateTime}
+          <TableCell component="th" scope="row" id="actionRuleDateTime">
+            {updatedDateTime}
           </TableCell>
           <TableCell component="th" scope="row">
             {!actionRule.hasTriggered &&

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.display-linebreak {
+  white-space: pre-line;
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We've noticed when rescheduling action rules that it's not displaying the correct times. It's expecting all the times to be bst so it's putting them back an hour which isn't what's reflected on the action rule table then. This is something we use in prod so it'll need to be fixed so it doesn't cause any confusion or problems
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
-  Updated the action rule trigger times to show in the timezone it's created in. So you'll see GMT for normal UTC times and GMT+01:00 for anything created in BST.
- Updated the rescheduling message so it now makes sense what you're updating
- Added IDs
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` and bring up the branch with Docker-Dev
- Run the attached Acceptance Tests PR and make sure all the tests pass
- Run the Acceptance Tests in GCP to make sure the behaviour is what we expect it to be
- Create a action rule manually on 21/12/2024. In Support Tool it should say it's created in GMT and the database entry for it should match exactly
- Create an action rule manually for todays date. Support Tool should say it's created in GMT+01:00  and show the current time. The database entry should be in UTC(An hour before)
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-619)
