### PR TITLE
Corporate Mac changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ui/node_modules
 
 # Megalinter reports
 megalinter-reports/
+
+# Podman secrets
+podman-build-secret*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 build:
 	./build.sh
 
@@ -7,13 +10,13 @@ build-no-test:
 test: test-mvn test-ui
 
 test-mvn:
-	mvn clean verify jacoco:report
+	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report
 
 test-ui:
 	cd ui && npm install && npx eslint . && npm test -- --watchAll=false
 
 run-dev-api: build
-	docker run -e spring_profiles_active=docker --network=ssdcrmdockerdev_default --link ons-postgres:postgres -p 9999:9999 europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
+	$(DOCKER) run -e spring_profiles_active=docker --network=ssdcrmdockerdev_default -p 9999:9999 europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 
 run-dev-ui:
 	cd ui && npm install && npm start
@@ -44,13 +47,13 @@ docker-build:
 	SKIP_TESTS=true ./build.sh
 
 megalint:  ## Run the mega-linter.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		oxsecurity/megalinter:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
 
 build:
-	./build.sh
+	DOCKER=$(DOCKER) ./build.sh
 
 build-no-test:
 	SKIP_TESTS=true ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	DOCKER=$(DOCKER) ./build.sh
 
 build-no-test:
-	SKIP_TESTS=true ./build.sh
+	DOCKER=$(DOCKER) SKIP_TESTS=true ./build.sh
 
 test: test-mvn test-ui
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ You can then edit the UI code in VSCode and run it, a new browser pointing to lo
 The code can be edited in VSCode without restarting the backend 'make run-dev-ui'
 
 
+## Building
+
+Podman and Docker are both supported for building and running the application.
+By default, the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+
+```shell
+DOCKER=docker make <command>
+```
+
+To run all tests and build the image:
+
+```shell
+   make build
+```
+
+Just build the image:
+
+```shell
+    make build-no-test
+```
+
 ## Security
 Not seeing the features you want or need? Try adding yourself as a super user, like this:
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER=$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 mkdir -p src/main/resources/static
 rm -r src/main/resources/static/* || true
 rm -r ui/build/* || true
@@ -16,8 +20,9 @@ cp -r ui/build/* src/main/resources/static
 rm -r ui/build/* || true
 
 if [ "$SKIP_TESTS" = true ] ; then
-  mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
+  CONTAINER_CLI=$DOCKER mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
 else
-  mvn clean install
+  CONTAINER_CLI=$DOCKER mvn clean install
 fi
-docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
+
+$DOCKER build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,6 @@
 # Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
 DOCKER=${DOCKER:-$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)}
 
-echo "Using container runtime: $DOCKER"
-
 mkdir -p src/main/resources/static
 rm -r src/main/resources/static/* || true
 rm -r ui/build/* || true

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,8 @@
 # Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
 DOCKER=${DOCKER:-$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)}
 
+echo "Using container runtime: $DOCKER"
+
 mkdir -p src/main/resources/static
 rm -r src/main/resources/static/* || true
 rm -r ui/build/* || true

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 # Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
-DOCKER=$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+DOCKER=${DOCKER:-$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)}
+
+echo "Testing Docker"
+echo "Using container runtime: $DOCKER"
 
 mkdir -p src/main/resources/static
 rm -r src/main/resources/static/* || true
@@ -25,4 +28,7 @@ else
   CONTAINER_CLI=$DOCKER mvn clean install
 fi
 
+echo "Testing Docker = $DOCKER"
 $DOCKER build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
+
+echo "Testing Docker = $DOCKER"

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,5 @@ else
   CONTAINER_CLI=$DOCKER mvn clean install
 fi
 
-echo "Testing Docker = $DOCKER"
 $DOCKER build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-support-tool:latest
 
-echo "Testing Docker = $DOCKER"

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,6 @@
 # Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
 DOCKER=${DOCKER:-$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)}
 
-echo "Testing Docker"
-echo "Using container runtime: $DOCKER"
-
 mkdir -p src/main/resources/static
 rm -r src/main/resources/static/* || true
 rm -r ui/build/* || true

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,25 @@
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
+    <container.cli>docker</container.cli>
   </properties>
+
+  <profiles>
+    <!-- Podman profile activated when env CONTAINER_CLI is set to "podman" -->
+    <!-- This is so podman will be used to run docker commands -->
+    <profile>
+      <id>podman</id>
+      <activation>
+        <property>
+          <name>env.CONTAINER_CLI</name>
+          <value>podman</value>
+        </property>
+      </activation>
+      <properties>
+        <container.cli>podman</container.cli>
+      </properties>
+    </profile>
+  </profiles>
 
   <dependencyManagement>
     <dependencies>
@@ -246,7 +264,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>docker</executable>
+              <executable>${container.cli}</executable>
               <commandlineArgs>compose -f src/test/resources/docker-compose.yml up -d</commandlineArgs>
             </configuration>
           </execution>
@@ -257,7 +275,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>docker</executable>
+              <executable>${container.cli}</executable>
               <commandlineArgs>compose -f src/test/resources/docker-compose.yml down -v</commandlineArgs>
             </configuration>
           </execution>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3223,6 +3223,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3521,12 +3533,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4068,7 +4082,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5471,6 +5484,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -7513,8 +7539,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -8263,11 +8263,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8277,12 +8277,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"


### PR DESCRIPTION
# Motivation and Context
This is so that all Makefile commands work on both old and new Macbooks.

# What has changed
- Updated the Makefile so that it uses docker or podman based on the Mac architecture.
- Note: `make run-dev-api` doesn't work, but that's the case on both old and new Macs.  A separae bug card has been raised to look into it.

# How to test?
Check that you can run checks, tests and builds on both old and new Macs.

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1484
