### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -47,10 +47,10 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 CMD ["java", "-jar", "/opt/ssdc-rm-support-tool.jar"]
 

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ run-dev-ui:
 	cd ui && npm install && npm start
 
 format-check-mvn:
-	mvn fmt:check
+	mvn spotless:check
 
 check-mvn:
-	mvn fmt:check pmd:check
+	mvn spotless:check pmd:check
 
 format-check-ui:
 	$(MAKE) -C ui format-check
@@ -33,7 +33,7 @@ format-check-ui:
 format-check: format-check-mvn format-check-ui
 
 format-mvn:
-	mvn fmt:format
+	mvn spotless:apply
 
 format-ui:
 	$(MAKE) -C ui format

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <java.version>21</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <container.cli>docker</container.cli>
   </properties>
 
@@ -216,7 +217,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.21.2</version>
+        <version>3.23.0</version>
         <configuration>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
@@ -295,21 +296,29 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.22.0</version> <!-- Java 21 compatible -->
+            </googleJavaFormat>
+          </java>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>check</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.11</version>
         <executions>
           <execution>
             <goals>
@@ -349,8 +358,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
@@ -365,7 +374,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.22</version>
+              <version>1.18.30</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/ActionRuleEndpoint.java
@@ -284,8 +284,8 @@ public class ActionRuleEndpoint {
           case SMS -> CREATE_SMS_ACTION_RULE;
           case EMAIL -> CREATE_EMAIL_ACTION_RULE;
           case EQ_FLUSH -> CREATE_EQ_FLUSH_ACTION_RULE;
-          default -> throw new IllegalStateException(
-              "Unexpected value: " + actionRuleDTO.getType());
+          default ->
+              throw new IllegalStateException("Unexpected value: " + actionRuleDTO.getType());
         };
 
     authUser.checkUserPermission(createdBy, collectionExercise.getSurvey().getId(), userActivity);

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/endpoint/UserGroupMemberEndpoint.java
@@ -69,7 +69,7 @@ public class UserGroupMemberEndpoint {
                 });
 
     return userGroupMemberRepository.findByUser(user).stream()
-        .map(this::mapGroupMember)
+        .map(member -> mapGroupMember(member))
         .collect(Collectors.toList());
   }
 
@@ -98,7 +98,7 @@ public class UserGroupMemberEndpoint {
     }
 
     return userGroupMemberRepository.findByGroup(group).stream()
-        .map(this::mapGroupMember)
+        .map(member -> mapGroupMember(member))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/supporttool/security/IAPUser.java
+++ b/src/main/java/uk/gov/ons/ssdc/supporttool/security/IAPUser.java
@@ -161,9 +161,10 @@ public class IAPUser implements AuthUser {
       JsonWebToken jsonWebToken = getTokenVerifier().verify(jwtToken);
 
       // Verify that the token contain subject and email claims
-      JsonWebToken.Payload payload = jsonWebToken.getPayload();
-      if (payload.getSubject() != null && payload.get("email") != null) {
-        return (String) payload.get("email");
+      String subject = jsonWebToken.getPayload().getSubject();
+      String email = (String) jsonWebToken.getPayload().get("email");
+      if (subject != null && email != null) {
+        return email;
       } else {
         return null;
       }


### PR DESCRIPTION
# Motivation and Context
Upgrade to Java 21

# What has changed
- Updated the pom file to use spotless instead of fmt and to parameterize the Java version so that it only has to be set once
- Updated Docker file to pull the Java 21 image
- Updated Git Actions
- Updated the Makefile
- Updated code that failed the spotless and pmd checks

# How to test?
Install Java 21 locally by running the dev-tools script (currently in PR)
All tests should pass and the image should build with no issues

# Links
[SDCSRM-1570](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570)


[SDCSRM-1570]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ